### PR TITLE
ci: auto review & merge workflow with Claude Code

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,252 @@
+name: Auto Review & Merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+  issues: write
+  id-token: write
+
+# Pre-cleanup: cancel redundant in-progress runs for the same PR
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  # ──────────────────────────────────────────────
+  # Pre-cleanup: remove stale review comments from
+  # previous pushes so the PR stays clean
+  # ──────────────────────────────────────────────
+  pre-cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove outdated Claude review comments
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const botComments = comments.filter(
+              c => c.user.type === 'Bot' &&
+                   (c.body.includes('Claude Code Review') || c.body.includes('Auto-merge skipped'))
+            );
+            for (const c of botComments) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: c.id,
+              });
+            }
+            console.log(`Cleaned ${botComments.length} stale review comment(s)`);
+
+  # ──────────────────────────────────────────────
+  # Build & Test
+  # NOTE: Requires macOS 26+ with Xcode 26 SDK.
+  # Use self-hosted runner if GitHub-hosted runners
+  # don't support macOS 26 yet:
+  #   runs-on: [self-hosted, macOS, ARM64]
+  # ──────────────────────────────────────────────
+  test:
+    needs: pre-cleanup
+    runs-on: macos-15
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: |
+          set -euo pipefail
+          XCODE=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
+          echo "Using $XCODE"
+          sudo xcode-select -s "$XCODE"
+          xcodebuild -version
+
+      - name: Build
+        run: |
+          set -euo pipefail
+          xcodebuild -scheme notetaker -configuration Debug build \
+            -destination 'platform=macOS' \
+            CODE_SIGNING_ALLOWED=NO 2>&1 | tail -5
+
+      - name: Run Unit Tests
+        run: |
+          set -euo pipefail
+          xcodebuild -scheme notetaker -configuration Debug \
+            -testPlan UnitTests \
+            -destination 'platform=macOS' \
+            CODE_SIGNING_ALLOWED=NO \
+            test 2>&1 | tail -20
+
+  # ──────────────────────────────────────────────
+  # Claude Code Review via claude-code-action
+  # Uses CLAUDE_CODE_OAUTH_TOKEN for auth.
+  # Claude reads CLAUDE.md for project conventions,
+  # reviews the diff, and posts a comment with
+  # APPROVE or REJECT decision.
+  # ──────────────────────────────────────────────
+  claude-review:
+    needs: pre-cleanup
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      decision: ${{ steps.parse.outputs.decision }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            You are reviewing this PR to decide if it can be AUTO-MERGED.
+            Use the repository's CLAUDE.md for style and convention guidance.
+
+            Review the PR diff for:
+            1. Code quality and adherence to project patterns
+            2. Potential bugs, crashes, or logic errors
+            3. Security concerns (secrets in code, injection, unsafe operations)
+            4. Test coverage — are tests updated if behavior changed?
+            5. PR description matches actual changes
+
+            After your review, you MUST post a comment using `gh pr comment` with this exact format:
+
+            ### <icon> Claude Code Review: **DECISION**
+            > reason
+
+            Where:
+            - DECISION is exactly "APPROVE" or "REJECT"
+            - icon is ✅ for APPROVE or ❌ for REJECT
+            - reason is a one-sentence explanation
+
+            APPROVE if changes are reasonable, safe, and follow project conventions.
+            REJECT if you find bugs, security issues, missing tests for behavior changes,
+            or suspicious mismatches between description and actual changes.
+
+          claude_args: '--allowed-tools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Read,Glob,Grep"'
+
+      - name: Parse decision from PR comments
+        id: parse
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Get the latest Claude review comment
+          COMMENT=$(gh pr view ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --json comments \
+            --jq '[.comments[] | select(.body | test("Claude Code Review"))] | last | .body // ""')
+
+          if echo "$COMMENT" | grep -q '**APPROVE**'; then
+            echo "decision=APPROVE" >> "$GITHUB_OUTPUT"
+            echo "Claude review: APPROVE"
+          else
+            echo "decision=REJECT" >> "$GITHUB_OUTPUT"
+            echo "Claude review: REJECT"
+          fi
+
+  # ──────────────────────────────────────────────
+  # Auto-merge: only if tests pass AND Claude approves
+  # ──────────────────────────────────────────────
+  auto-merge:
+    needs: [test, claude-review]
+    if: needs.claude-review.outputs.decision == 'APPROVE'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr review ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --approve \
+            --body "Auto-approved: tests passed and Claude Code review approved."
+
+      - name: Merge PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --merge \
+            --delete-branch
+
+  # ──────────────────────────────────────────────
+  # Post-cleanup: runs after merge (or on failure)
+  # ──────────────────────────────────────────────
+  post-cleanup:
+    needs: [auto-merge]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clean up old workflow runs (>30 days)
+        if: needs.auto-merge.result == 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+            const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+              status: 'completed',
+            });
+            let deleted = 0;
+            for (const run of runs.workflow_runs) {
+              if (new Date(run.created_at) < thirtyDaysAgo) {
+                try {
+                  await github.rest.actions.deleteWorkflowRun({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    run_id: run.id,
+                  });
+                  deleted++;
+                } catch (e) { /* skip in-progress */ }
+              }
+            }
+            console.log(`Deleted ${deleted} old workflow run(s)`);
+
+      - name: Clean up stale merged branches
+        if: needs.auto-merge.result == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh api repos/${{ github.repository }}/branches --paginate -q '.[].name' | while read -r branch; do
+            case "$branch" in main|master|develop) continue ;; esac
+            MERGED=$(gh pr list --head "$branch" --state merged --json number --jq 'length')
+            if [ "$MERGED" -gt 0 ]; then
+              echo "Deleting stale merged branch: $branch"
+              gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/$branch" 2>/dev/null || true
+            fi
+          done
+
+      - name: Post failure notice
+        if: needs.auto-merge.result == 'failure' || needs.auto-merge.result == 'skipped'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const decision = '${{ needs.claude-review.outputs.decision }}';
+            const reason = decision !== 'APPROVE'
+              ? 'Claude Code review did not approve'
+              : 'Tests or merge failed';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `:warning: **Auto-merge skipped**: ${reason}. Manual review required.`,
+            });


### PR DESCRIPTION
## Summary

- Add `.github/workflows/auto-merge.yml` — auto-merges PRs when tests pass + Claude Code approves
- Uses `anthropics/claude-code-action@v1` with `CLAUDE_CODE_OAUTH_TOKEN`
- Pre-cleanup: concurrency group cancels redundant runs, deletes stale review comments
- Post-cleanup: removes old workflow runs (>30d), deletes stale merged branches, posts failure notice

Closes #46

## Required Setup

Set `CLAUDE_CODE_OAUTH_TOKEN` in repo Settings > Secrets > Actions.

## Test plan

- [ ] Verify workflow triggers on PR open/sync
- [ ] Verify Claude posts review comment with APPROVE/REJECT
- [ ] Verify auto-merge on APPROVE + test pass
- [ ] Verify failure notice on REJECT