### PR TITLE
feat: one-click copy summary as Markdown

### DIFF
--- a/notetaker/Services/SummaryMarkdownFormatter.swift
+++ b/notetaker/Services/SummaryMarkdownFormatter.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+enum SummaryMarkdownFormatter {
+    /// Formats summary content as Markdown with appropriate heading.
+    /// - Parameters:
+    ///   - content: The summary text (use `displayContent` for edited summaries).
+    ///   - coveringFrom: Start time in seconds.
+    ///   - coveringTo: End time in seconds.
+    ///   - isOverall: Whether this is an overall summary.
+    /// - Returns: Markdown-formatted string.
+    static func format(
+        content: String,
+        coveringFrom: TimeInterval,
+        coveringTo: TimeInterval,
+        isOverall: Bool
+    ) -> String {
+        let heading: String
+        if isOverall {
+            heading = "## Overall Summary"
+        } else {
+            heading = "## \(coveringFrom.mmss)–\(coveringTo.mmss)"
+        }
+        return "\(heading)\n\n\(content)"
+    }
+}

--- a/notetaker/Views/SummaryCardView.swift
+++ b/notetaker/Views/SummaryCardView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import os
 
 struct SummaryCardView: View {
     let coveringFrom: TimeInterval
@@ -17,6 +18,9 @@ struct SummaryCardView: View {
     @State private var showRegenerateField = false
     @State private var regenerateInstructions = ""
     @State private var isHovered = false
+    @State private var showCopiedFeedback = false
+
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "notetaker", category: "SummaryCardView")
 
     init(
         coveringFrom: TimeInterval,
@@ -94,8 +98,10 @@ struct SummaryCardView: View {
         }
         .padding(.vertical, DS.Spacing.xs)
         .overlay(alignment: .topTrailing) {
-            if !isEditing && !showRegenerateField && isHovered && (onSave != nil || onRegenerate != nil) {
+            if !isEditing && !showRegenerateField && (isHovered || showCopiedFeedback) {
                 HStack(spacing: DS.Spacing.xs) {
+                    copyButton
+
                     if onSave != nil {
                         Button {
                             editText = content
@@ -124,6 +130,43 @@ struct SummaryCardView: View {
             }
         }
         .onHover { isHovered = $0 }
+    }
+
+    // MARK: - Copy
+
+    @ViewBuilder
+    private var copyButton: some View {
+        Button(action: copySummaryAsMarkdown) {
+            Image(systemName: showCopiedFeedback ? "checkmark" : "doc.on.doc")
+                .font(DS.Typography.caption2)
+                .contentTransition(.symbolEffect(.replace))
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(showCopiedFeedback ? AnyShapeStyle(.green) : AnyShapeStyle(.tertiary))
+        .help("Copy summary (Markdown)")
+        .accessibilityLabel("Copy summary to clipboard")
+    }
+
+    private func copySummaryAsMarkdown() {
+        let markdown = SummaryMarkdownFormatter.format(
+            content: content,
+            coveringFrom: coveringFrom,
+            coveringTo: coveringTo,
+            isOverall: isOverall
+        )
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(markdown, forType: .string)
+        Self.logger.debug("Copied summary to clipboard (\(markdown.count) chars)")
+
+        withAnimation(.easeInOut(duration: 0.2)) {
+            showCopiedFeedback = true
+        }
+        Task {
+            try? await Task.sleep(for: .seconds(1.5))
+            withAnimation(.easeInOut(duration: 0.2)) {
+                showCopiedFeedback = false
+            }
+        }
     }
 
     // MARK: - Subviews

--- a/notetakerTests/SummaryMarkdownFormatterTests.swift
+++ b/notetakerTests/SummaryMarkdownFormatterTests.swift
@@ -1,0 +1,74 @@
+import Testing
+@testable import notetaker
+
+@Suite("SummaryMarkdownFormatter")
+struct SummaryMarkdownFormatterTests {
+
+    @Test("Overall summary formats with 'Overall Summary' heading")
+    func overallSummaryFormat() {
+        let result = SummaryMarkdownFormatter.format(
+            content: "Key points from the meeting.",
+            coveringFrom: 0,
+            coveringTo: 300,
+            isOverall: true
+        )
+        #expect(result == "## Overall Summary\n\nKey points from the meeting.")
+    }
+
+    @Test("Chunk summary formats with time range heading")
+    func chunkSummaryFormat() {
+        let result = SummaryMarkdownFormatter.format(
+            content: "Discussion about architecture.",
+            coveringFrom: 0,
+            coveringTo: 300,
+            isOverall: false
+        )
+        #expect(result == "## 00:00–05:00\n\nDiscussion about architecture.")
+    }
+
+    @Test("Chunk summary with non-zero start time")
+    func chunkSummaryNonZeroStart() {
+        let result = SummaryMarkdownFormatter.format(
+            content: "Budget review.",
+            coveringFrom: 300,
+            coveringTo: 600,
+            isOverall: false
+        )
+        #expect(result == "## 05:00–10:00\n\nBudget review.")
+    }
+
+    @Test("Multiline content preserved as-is")
+    func multilineContent() {
+        let content = "- Point one\n- Point two\n- Point three"
+        let result = SummaryMarkdownFormatter.format(
+            content: content,
+            coveringFrom: 0,
+            coveringTo: 120,
+            isOverall: true
+        )
+        #expect(result == "## Overall Summary\n\n- Point one\n- Point two\n- Point three")
+    }
+
+    @Test("Empty content produces heading only")
+    func emptyContent() {
+        let result = SummaryMarkdownFormatter.format(
+            content: "",
+            coveringFrom: 0,
+            coveringTo: 60,
+            isOverall: false
+        )
+        #expect(result == "## 00:00–01:00\n\n")
+    }
+
+    @Test("Long duration uses mm:ss format")
+    func longDuration() {
+        let result = SummaryMarkdownFormatter.format(
+            content: "Summary text.",
+            coveringFrom: 3600,
+            coveringTo: 7200,
+            isOverall: false
+        )
+        // mmss: 3600 -> 60:00, 7200 -> 120:00
+        #expect(result == "## 60:00–120:00\n\nSummary text.")
+    }
+}


### PR DESCRIPTION
## Summary
- Add hover-to-reveal copy button on `SummaryCardView` (doc.on.doc icon → green checkmark)
- Copies summary as Markdown with heading (`## Overall Summary` or `## mm:ss–mm:ss`) to clipboard
- `SummaryMarkdownFormatter` enum for testable formatting logic
- 6 unit tests covering overall/chunk/multiline/empty/long-duration cases

Closes #38

## Test plan
- [x] Unit tests pass: `SummaryMarkdownFormatterTests` (6 tests)
- [x] Full UnitTests plan passes (330 tests)
- [x] Manual: hover over summary card → copy button appears
- [x] Manual: click copy → checkmark animation → paste in Obsidian/Notion → Markdown renders
- [x] Manual: button disappears on mouse leave
- [x] Manual: no layout shift when button appears/disappears