### PR TITLE
feat: Markdown export with YAML frontmatter

### DIFF
--- a/UnitTests.xctestplan
+++ b/UnitTests.xctestplan
@@ -32,6 +32,7 @@
         "LLMProviderCoverageTests",
         "LLMProviderTests",
         "LLMRoleCoverageTests",
+        "MarkdownExporterTests",
         "NoopEngineTests",
         "PromptBuilderExtendedTests",
         "PromptBuilderTests",

--- a/notetaker/Services/MarkdownExporter.swift
+++ b/notetaker/Services/MarkdownExporter.swift
@@ -1,0 +1,176 @@
+import Foundation
+import os
+
+nonisolated enum MarkdownExporter {
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "notetaker",
+        category: "MarkdownExporter"
+    )
+
+    // MARK: - Data types
+
+    struct ExportOptions: Sendable {
+        var includeYAMLFrontmatter: Bool = true
+        var includeSummary: Bool = true
+        var includeTranscript: Bool = true
+        var transcriptFormat: TranscriptFormat = .timestamped
+        var customTags: [String] = []
+    }
+
+    enum TranscriptFormat: Sendable {
+        case table
+        case timestamped
+    }
+
+    struct SummaryInfo: Sendable {
+        let content: String
+        let coveringFrom: TimeInterval
+        let coveringTo: TimeInterval
+        let isOverall: Bool
+    }
+
+    struct SegmentInfo: Sendable {
+        let startTime: TimeInterval
+        let text: String
+    }
+
+    // MARK: - Export
+
+    static func export(
+        title: String,
+        date: Date,
+        totalDuration: TimeInterval,
+        segments: [SegmentInfo],
+        summaries: [SummaryInfo],
+        options: ExportOptions
+    ) -> String {
+        logger.info("Exporting Markdown: title=\(title), segments=\(segments.count), summaries=\(summaries.count)")
+        var parts: [String] = []
+
+        if options.includeYAMLFrontmatter {
+            parts.append(generateFrontmatter(
+                title: title,
+                date: date,
+                totalDuration: totalDuration,
+                segmentsCount: segments.count,
+                tags: options.customTags
+            ))
+        }
+
+        if options.includeSummary {
+            let summarySection = formatSummaries(summaries)
+            if !summarySection.isEmpty {
+                parts.append("# Summary\n\n\(summarySection)")
+            }
+        }
+
+        if options.includeTranscript && !segments.isEmpty {
+            let transcriptSection = formatTranscript(segments, format: options.transcriptFormat)
+            parts.append("# Transcript\n\n\(transcriptSection)")
+        }
+
+        return parts.joined(separator: "\n\n")
+    }
+
+    // MARK: - Frontmatter
+
+    static func generateFrontmatter(
+        title: String,
+        date: Date,
+        totalDuration: TimeInterval,
+        segmentsCount: Int,
+        tags: [String]
+    ) -> String {
+        let escapedTitle = title
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        let iso8601 = ISO8601DateFormatter()
+        iso8601.formatOptions = [.withInternetDateTime]
+        let dateString = iso8601.string(from: date)
+        let durationString = totalDuration.hhmmss
+
+        var lines: [String] = [
+            "---",
+            "title: \"\(escapedTitle)\"",
+            "date: \(dateString)",
+            "duration: \"\(durationString)\"",
+            "duration_seconds: \(Int(totalDuration))",
+            "type: meeting-note",
+            "source: notetaker",
+        ]
+
+        if !tags.isEmpty {
+            lines.append("tags:")
+            for tag in tags {
+                lines.append("  - \(tag)")
+            }
+        }
+
+        lines.append("segments_count: \(segmentsCount)")
+        lines.append("---")
+
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    // MARK: - Summaries
+
+    static func formatSummaries(_ summaries: [SummaryInfo]) -> String {
+        guard !summaries.isEmpty else { return "" }
+
+        var parts: [String] = []
+
+        // Overall summaries first
+        let overalls = summaries.filter(\.isOverall)
+        for summary in overalls {
+            parts.append("## Overall Summary\n\n\(summary.content)")
+        }
+
+        // Chunk summaries sorted by time
+        let chunks = summaries
+            .filter { !$0.isOverall }
+            .sorted { $0.coveringFrom < $1.coveringFrom }
+        for chunk in chunks {
+            let from = chunk.coveringFrom.mmss
+            let to = chunk.coveringTo.mmss
+            parts.append("## \(from)–\(to)\n\n\(chunk.content)")
+        }
+
+        return parts.joined(separator: "\n\n")
+    }
+
+    // MARK: - Transcript
+
+    static func formatTranscript(
+        _ segments: [SegmentInfo],
+        format: TranscriptFormat
+    ) -> String {
+        switch format {
+        case .timestamped:
+            return segments
+                .map { "[\($0.startTime.mmss)] \($0.text)" }
+                .joined(separator: "\n")
+
+        case .table:
+            var lines = [
+                "| Time | Content |",
+                "|------|---------|",
+            ]
+            for segment in segments {
+                lines.append("| \(segment.startTime.mmss) | \(segment.text) |")
+            }
+            return lines.joined(separator: "\n")
+        }
+    }
+
+    // MARK: - Filename
+
+    static func sanitizeFilename(_ name: String) -> String {
+        let illegal = CharacterSet(charactersIn: "/\\:*?\"<>|")
+        let sanitized = name.unicodeScalars
+            .filter { !illegal.contains($0) }
+            .map { String($0) }
+            .joined()
+        return sanitized.isEmpty ? "untitled" : sanitized
+    }
+}

--- a/notetaker/Views/SessionDetailView.swift
+++ b/notetaker/Views/SessionDetailView.swift
@@ -20,6 +20,7 @@ struct SessionDetailView: View {
     @State private var scrollToTime: TimeInterval?
     @State private var refreshTimer: Timer?
     @State private var isExportingAudio = false
+    @State private var markdownExportFeedback: String?
     @AppStorage("overallSummaryCollapsed") private var overallCollapsed = false
     @AppStorage("overallSummaryHeight") private var overallHeight: Double = 300
     @AppStorage("chunkSummariesHidden") private var chunkSummariesHidden = false
@@ -75,6 +76,26 @@ struct SessionDetailView: View {
                             Label("Share Transcript", systemImage: "square.and.arrow.up")
                         }
                         .disabled(sortedSegments.isEmpty)
+
+                        Button {
+                            exportMarkdown(session: session)
+                        } label: {
+                            Label("Export Markdown", systemImage: "doc.text")
+                        }
+                        .keyboardShortcut("e", modifiers: .command)
+                        .disabled(sortedSegments.isEmpty)
+
+                        if let markdownExportFeedback {
+                            Text(markdownExportFeedback)
+                                .font(DS.Typography.caption)
+                                .foregroundStyle(.secondary)
+                                .transition(.opacity)
+                                .task(id: markdownExportFeedback) {
+                                    try? await Task.sleep(for: .seconds(3))
+                                    guard !Task.isCancelled else { return }
+                                    self.markdownExportFeedback = nil
+                                }
+                        }
 
                         if isGeneratingSummary {
                             ProgressView().controlSize(.small)
@@ -244,6 +265,7 @@ struct SessionDetailView: View {
                 summaryGenerationError = nil
                 summaryProgress = nil
                 scrollToTime = nil
+                markdownExportFeedback = nil
                 showChatPanel = false
                 fetchSession()
             }
@@ -569,6 +591,45 @@ struct SessionDetailView: View {
                 summaryGenerationError = error.localizedDescription
             }
             isGeneratingSummary = false
+        }
+    }
+
+    private func exportMarkdown(session: RecordingSession) {
+        let segments = sortedSegments.map {
+            MarkdownExporter.SegmentInfo(startTime: $0.startTime, text: $0.text)
+        }
+        let summaries = session.summaries.map {
+            MarkdownExporter.SummaryInfo(
+                content: $0.displayContent,
+                coveringFrom: $0.coveringFrom,
+                coveringTo: $0.coveringTo,
+                isOverall: $0.isOverall
+            )
+        }
+
+        let markdown = MarkdownExporter.export(
+            title: session.title,
+            date: session.startedAt,
+            totalDuration: session.totalDuration,
+            segments: segments,
+            summaries: summaries,
+            options: .init()
+        )
+
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [UTType(filenameExtension: "md") ?? .plainText]
+        let baseName = MarkdownExporter.sanitizeFilename(session.title)
+        panel.nameFieldStringValue = "\(baseName).md"
+
+        guard panel.runModal() == .OK, let destURL = panel.url else { return }
+
+        do {
+            try markdown.write(to: destURL, atomically: true, encoding: .utf8)
+            markdownExportFeedback = "Exported!"
+            Self.logger.info("Markdown exported to \(destURL.path)")
+        } catch {
+            Self.logger.error("Markdown export failed: \(error.localizedDescription)")
+            markdownExportFeedback = "Export failed"
         }
     }
 

--- a/notetakerTests/MarkdownExporterTests.swift
+++ b/notetakerTests/MarkdownExporterTests.swift
@@ -1,0 +1,179 @@
+import Foundation
+import Testing
+@testable import notetaker
+
+struct MarkdownExporterTests {
+
+    // MARK: - Frontmatter
+
+    @Test func testFrontmatterBasic() {
+        let date = Date(timeIntervalSince1970: 1_711_612_200) // 2024-03-28T14:30:00+00:00
+        let result = MarkdownExporter.generateFrontmatter(
+            title: "My Session",
+            date: date,
+            totalDuration: 5025,
+            segmentsCount: 87,
+            tags: ["meeting"]
+        )
+        #expect(result.hasPrefix("---\n"))
+        #expect(result.hasSuffix("---\n"))
+        #expect(result.contains("title: \"My Session\""))
+        #expect(result.contains("duration: \"01:23:45\""))
+        #expect(result.contains("duration_seconds: 5025"))
+        #expect(result.contains("type: meeting-note"))
+        #expect(result.contains("source: notetaker"))
+        #expect(result.contains("segments_count: 87"))
+        #expect(result.contains("tags:"))
+        #expect(result.contains("  - meeting"))
+        #expect(result.contains("date: "))
+    }
+
+    @Test func testFrontmatterEscapesQuotes() {
+        let result = MarkdownExporter.generateFrontmatter(
+            title: "He said \"hello\"",
+            date: Date(),
+            totalDuration: 60,
+            segmentsCount: 1,
+            tags: []
+        )
+        #expect(result.contains("title: \"He said \\\"hello\\\"\""))
+    }
+
+    @Test func testFrontmatterEscapesColons() {
+        let result = MarkdownExporter.generateFrontmatter(
+            title: "Meeting: Important",
+            date: Date(),
+            totalDuration: 60,
+            segmentsCount: 1,
+            tags: []
+        )
+        // Title with colons should be quoted (it already is)
+        #expect(result.contains("title: \"Meeting: Important\""))
+    }
+
+    @Test func testFrontmatterNoTags() {
+        let result = MarkdownExporter.generateFrontmatter(
+            title: "Test",
+            date: Date(),
+            totalDuration: 60,
+            segmentsCount: 1,
+            tags: []
+        )
+        #expect(!result.contains("tags:"))
+    }
+
+    // MARK: - Summaries
+
+    @Test func testFormatSummariesOverallAndChunks() {
+        let summaries: [MarkdownExporter.SummaryInfo] = [
+            .init(content: "Chunk B", coveringFrom: 300, coveringTo: 600, isOverall: false),
+            .init(content: "Overall content", coveringFrom: 0, coveringTo: 600, isOverall: true),
+            .init(content: "Chunk A", coveringFrom: 0, coveringTo: 300, isOverall: false),
+        ]
+        let result = MarkdownExporter.formatSummaries(summaries)
+        let overallIndex = result.range(of: "Overall content")!.lowerBound
+        let chunkAIndex = result.range(of: "Chunk A")!.lowerBound
+        let chunkBIndex = result.range(of: "Chunk B")!.lowerBound
+        // Overall comes first
+        #expect(overallIndex < chunkAIndex)
+        // Chunks sorted by time
+        #expect(chunkAIndex < chunkBIndex)
+        // Section headers
+        #expect(result.contains("## Overall Summary"))
+        #expect(result.contains("## 00:00–05:00"))
+        #expect(result.contains("## 05:00–10:00"))
+    }
+
+    @Test func testFormatSummariesEmpty() {
+        let result = MarkdownExporter.formatSummaries([])
+        #expect(result.isEmpty)
+    }
+
+    // MARK: - Transcript
+
+    @Test func testFormatTranscriptTimestamped() {
+        let segments: [MarkdownExporter.SegmentInfo] = [
+            .init(startTime: 0, text: "Hello"),
+            .init(startTime: 65, text: "World"),
+        ]
+        let result = MarkdownExporter.formatTranscript(segments, format: .timestamped)
+        #expect(result.contains("[00:00] Hello"))
+        #expect(result.contains("[01:05] World"))
+    }
+
+    @Test func testFormatTranscriptTable() {
+        let segments: [MarkdownExporter.SegmentInfo] = [
+            .init(startTime: 0, text: "Hello"),
+            .init(startTime: 65, text: "World"),
+        ]
+        let result = MarkdownExporter.formatTranscript(segments, format: .table)
+        #expect(result.contains("| Time | Content |"))
+        #expect(result.contains("|------|---------|"))
+        #expect(result.contains("| 00:00 | Hello |"))
+        #expect(result.contains("| 01:05 | World |"))
+    }
+
+    // MARK: - Sanitize
+
+    @Test func testSanitizeFilename() {
+        #expect(MarkdownExporter.sanitizeFilename("My/File:Name*Test") == "MyFileNameTest")
+        #expect(MarkdownExporter.sanitizeFilename("normal-file_name") == "normal-file_name")
+        #expect(MarkdownExporter.sanitizeFilename("") == "untitled")
+        #expect(MarkdownExporter.sanitizeFilename("a\"b<c>d|e?f\\g") == "abcdefg")
+    }
+
+    // MARK: - Full export
+
+    @Test func testExportFullDocument() {
+        let segments: [MarkdownExporter.SegmentInfo] = [
+            .init(startTime: 0, text: "Hello"),
+        ]
+        let summaries: [MarkdownExporter.SummaryInfo] = [
+            .init(content: "Summary text", coveringFrom: 0, coveringTo: 60, isOverall: true),
+        ]
+        let result = MarkdownExporter.export(
+            title: "Test Session",
+            date: Date(),
+            totalDuration: 60,
+            segments: segments,
+            summaries: summaries,
+            options: .init()
+        )
+        // Should have frontmatter, summary section, transcript section
+        #expect(result.hasPrefix("---\n"))
+        #expect(result.contains("# Summary"))
+        #expect(result.contains("Summary text"))
+        #expect(result.contains("# Transcript"))
+        #expect(result.contains("[00:00] Hello"))
+    }
+
+    @Test func testExportWithoutFrontmatter() {
+        let result = MarkdownExporter.export(
+            title: "Test",
+            date: Date(),
+            totalDuration: 60,
+            segments: [.init(startTime: 0, text: "Hi")],
+            summaries: [],
+            options: .init(includeYAMLFrontmatter: false)
+        )
+        #expect(!result.hasPrefix("---\n"))
+        #expect(result.contains("# Transcript"))
+    }
+
+    @Test func testExportWithoutSummary() {
+        let summaries: [MarkdownExporter.SummaryInfo] = [
+            .init(content: "Should not appear", coveringFrom: 0, coveringTo: 60, isOverall: true),
+        ]
+        let result = MarkdownExporter.export(
+            title: "Test",
+            date: Date(),
+            totalDuration: 60,
+            segments: [.init(startTime: 0, text: "Hi")],
+            summaries: summaries,
+            options: .init(includeSummary: false)
+        )
+        #expect(!result.contains("# Summary"))
+        #expect(!result.contains("Should not appear"))
+        #expect(result.contains("# Transcript"))
+    }
+}


### PR DESCRIPTION
## Summary
- MarkdownExporter service with YAML frontmatter, timestamped/table formats
- Export Markdown toolbar button (⌘E) in SessionDetailView
- 12 unit tests

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)