### PR TITLE
feat: auto-title sessions from first transcript

### DIFF
--- a/UnitTests.xctestplan
+++ b/UnitTests.xctestplan
@@ -18,6 +18,7 @@
         "name" : "notetakerTests"
       },
       "selectedTests" : [
+        "AutoTitleTests",
         "AudioConfigTests",
         "ChatServiceTests",
         "AudioExporterTests",

--- a/notetaker/Services/AutoTitleGenerator.swift
+++ b/notetaker/Services/AutoTitleGenerator.swift
@@ -1,0 +1,71 @@
+import Foundation
+import os
+
+/// Generates a short auto-title from the first transcript text.
+/// Extracted as nonisolated enum for testability.
+nonisolated enum AutoTitleGenerator {
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "notetaker", category: "AutoTitleGenerator")
+
+    /// Filler words to strip before generating title
+    private static let fillerWords: Set<String> = [
+        "um", "uh", "er", "ah", "like", "you know", "so", "well",
+        "嗯", "啊", "那个", "就是", "然后", "对", "哦"
+    ]
+
+    /// Generate a title from transcript text.
+    /// Returns nil if text is too short or only filler words.
+    static func generate(from text: String) -> String? {
+        let cleaned = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleaned.isEmpty else { return nil }
+
+        let isCJK = cleaned.unicodeScalars.contains {
+            (0x4E00...0x9FFF).contains($0.value) ||
+            (0x3400...0x4DBF).contains($0.value)
+        }
+
+        if isCJK {
+            return generateCJKTitle(from: cleaned)
+        } else {
+            return generateLatinTitle(from: cleaned)
+        }
+    }
+
+    private static func generateCJKTitle(from text: String) -> String? {
+        // Filter filler: remove known filler substrings from start
+        var t = text
+        for filler in fillerWords {
+            while t.hasPrefix(filler) {
+                t = String(t.dropFirst(filler.count)).trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+        }
+        guard t.count >= 3 else { return nil }
+
+        let maxLen = 20
+        if t.count <= maxLen {
+            return t
+        }
+        return String(t.prefix(maxLen)) + "…"
+    }
+
+    private static func generateLatinTitle(from text: String) -> String? {
+        let words = text.split(separator: " ").map(String.init)
+        // Filter filler words (case-insensitive)
+        let meaningful = words.filter { !fillerWords.contains($0.lowercased()) }
+        guard meaningful.count >= 2 else { return nil }
+
+        let maxWords = 8
+        let selected = Array(meaningful.prefix(maxWords))
+        let title = selected.joined(separator: " ")
+
+        if meaningful.count > maxWords {
+            return title + "…"
+        }
+        return title
+    }
+
+    /// Check if a title is a default auto-generated title (not user-edited).
+    static func isDefaultTitle(_ title: String) -> Bool {
+        // Default format: "Recording Mar 24, 2026, 2:30 PM" or similar locale variations
+        title.hasPrefix("Recording ")
+    }
+}

--- a/notetaker/ViewModels/RecordingViewModel.swift
+++ b/notetaker/ViewModels/RecordingViewModel.swift
@@ -73,6 +73,7 @@ final class RecordingViewModel {
     private var periodicWindowCount: Int = 0
     private var llmConfigObserver: NSObjectProtocol?
     private let vadConfig: VADConfig
+    private var hasAutoTitled = false
 
     // Duration-end timer state (2c)
     private var durationEndTimer: Timer?
@@ -284,6 +285,7 @@ final class RecordingViewModel {
         clock.reset()
         clipTimeOffset = 0
         pausedElapsedTime = 0
+        hasAutoTitled = false
     }
 
     // MARK: - Pause / Resume
@@ -715,6 +717,16 @@ final class RecordingViewModel {
             )
             segments.append(segment)
             partialText = ""
+
+            // Auto-title from first meaningful segment (try up to first 5 segments)
+            if !hasAutoTitled && segments.count <= 5,
+               let session = currentSession,
+               AutoTitleGenerator.isDefaultTitle(session.title),
+               let title = AutoTitleGenerator.generate(from: result.text) {
+                session.title = title
+                hasAutoTitled = true
+                Self.logger.info("Auto-titled session: \(title)")
+            }
         } else {
             partialText = result.text
         }

--- a/notetakerTests/AutoTitleTests.swift
+++ b/notetakerTests/AutoTitleTests.swift
@@ -1,0 +1,71 @@
+import Testing
+@testable import notetaker
+
+@Suite("AutoTitleGenerator")
+struct AutoTitleTests {
+    @Test func englishTruncation() {
+        let text = "Today we are going to discuss the product roadmap and timeline for Q3"
+        let title = AutoTitleGenerator.generate(from: text)
+        #expect(title != nil)
+        let words = title!.split(separator: " ")
+        #expect(words.count <= 9) // 8 words + possible ellipsis as part of last word
+        #expect(title!.hasSuffix("…"))
+    }
+
+    @Test func englishShort() {
+        let text = "Hello world meeting"
+        let title = AutoTitleGenerator.generate(from: text)
+        #expect(title == "Hello world meeting")
+    }
+
+    @Test func chineseTruncation() {
+        let text = "今天我们来讨论一下关于产品路线图的最新进展和下一步计划"
+        let title = AutoTitleGenerator.generate(from: text)
+        #expect(title != nil)
+        #expect(title!.count <= 21) // 20 chars + ellipsis
+        #expect(title!.hasSuffix("…"))
+    }
+
+    @Test func chineseShort() {
+        let text = "今天开会讨论"
+        let title = AutoTitleGenerator.generate(from: text)
+        #expect(title == "今天开会讨论")
+    }
+
+    @Test func fillerWordsFiltered() {
+        let text = "um uh like the project update"
+        let title = AutoTitleGenerator.generate(from: text)
+        #expect(title != nil)
+        #expect(!title!.lowercased().contains("um"))
+        #expect(!title!.lowercased().contains("uh"))
+    }
+
+    @Test func chineseFillerFiltered() {
+        let text = "嗯那个就是今天讨论产品方案"
+        let title = AutoTitleGenerator.generate(from: text)
+        #expect(title != nil)
+        #expect(!title!.hasPrefix("嗯"))
+    }
+
+    @Test func tooShortReturnsNil() {
+        #expect(AutoTitleGenerator.generate(from: "um") == nil)
+        #expect(AutoTitleGenerator.generate(from: "uh like") == nil)
+        #expect(AutoTitleGenerator.generate(from: "") == nil)
+    }
+
+    @Test func emptyReturnsNil() {
+        #expect(AutoTitleGenerator.generate(from: "") == nil)
+        #expect(AutoTitleGenerator.generate(from: "   ") == nil)
+    }
+
+    @Test func isDefaultTitle() {
+        #expect(AutoTitleGenerator.isDefaultTitle("Recording Mar 24, 2026, 2:30 PM"))
+        #expect(AutoTitleGenerator.isDefaultTitle("Recording 2026-03-24"))
+        #expect(!AutoTitleGenerator.isDefaultTitle("My Custom Title"))
+        #expect(!AutoTitleGenerator.isDefaultTitle("Product Discussion"))
+    }
+
+    @Test func onlyFillerReturnsNil() {
+        #expect(AutoTitleGenerator.generate(from: "um uh like") == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- AutoTitleGenerator: CJK/Latin truncation, filler word filtering
- RecordingViewModel integration on first 5 final segments
- 10 unit tests

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)