### PR TITLE
feat: summary word count and duration metrics

### DIFF
--- a/UnitTests.xctestplan
+++ b/UnitTests.xctestplan
@@ -49,7 +49,8 @@
         "SyntheticBufferInjectionTests",
         "TimeIntervalFormattingTests",
         "TranscriptSegmentTests",
-        "VADConfigTests"
+        "VADConfigTests",
+        "WordCounterTests"
       ]
     }
   ],

--- a/notetaker/Services/WordCounter.swift
+++ b/notetaker/Services/WordCounter.swift
@@ -1,0 +1,66 @@
+import Foundation
+import os
+
+/// Word counting and metrics formatting for summary content.
+nonisolated enum WordCounter {
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "notetaker", category: "WordCounter")
+
+    /// Count words in text, handling both CJK and Latin scripts.
+    static func count(in text: String) -> Int {
+        let cleaned = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleaned.isEmpty else { return 0 }
+
+        if isCJKDominant(cleaned) {
+            // CJK-dominant: count meaningful characters (no whitespace, no punctuation)
+            let count = cleaned.filter { !$0.isWhitespace && !$0.isPunctuation }.count
+            logger.debug("CJK word count: \(count) chars")
+            return count
+        } else {
+            // Latin-dominant: count words by whitespace splitting
+            let count = cleaned.split(whereSeparator: { $0.isWhitespace }).count
+            logger.debug("Latin word count: \(count) words")
+            return count
+        }
+    }
+
+    /// Format word count and duration into a compact display string.
+    /// - Parameters:
+    ///   - wordCount: Number of words
+    ///   - duration: Duration in seconds (coveringTo - coveringFrom)
+    ///   - isCJK: Whether the text is CJK-dominant
+    /// - Returns: Formatted string like "~320 words · 5 min" or "~150 字 · 3 min"
+    static func formatMetrics(wordCount: Int, duration: TimeInterval, isCJK: Bool = false) -> String {
+        let wordLabel = isCJK ? "字" : (wordCount == 1 ? "word" : "words")
+        let durationStr: String
+        if duration < 60 {
+            durationStr = "\(Int(duration))s"
+        } else {
+            let minutes = Int(duration / 60)
+            let seconds = Int(duration.truncatingRemainder(dividingBy: 60))
+            if seconds == 0 {
+                durationStr = "\(minutes) min"
+            } else {
+                durationStr = "\(minutes)m \(seconds)s"
+            }
+        }
+        return "~\(wordCount) \(wordLabel) · \(durationStr)"
+    }
+
+    /// Format word count only (no duration), for overall summaries.
+    static func formatWordCount(wordCount: Int, isCJK: Bool = false) -> String {
+        let wordLabel = isCJK ? "字" : (wordCount == 1 ? "word" : "words")
+        return "~\(wordCount) \(wordLabel)"
+    }
+
+    /// Detect if text is primarily CJK.
+    static func isCJKDominant(_ text: String) -> Bool {
+        let cleaned = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleaned.isEmpty else { return false }
+        let cjkCount = cleaned.unicodeScalars.filter {
+            (0x4E00...0x9FFF).contains($0.value) ||
+            (0x3400...0x4DBF).contains($0.value)
+        }.count
+        let totalNonSpace = cleaned.filter { !$0.isWhitespace }.count
+        return totalNonSpace > 0 && Double(cjkCount) / Double(totalNonSpace) > 0.3
+    }
+}

--- a/notetaker/Views/SummaryCardView.swift
+++ b/notetaker/Views/SummaryCardView.swift
@@ -91,7 +91,33 @@ struct SummaryCardView: View {
                     }
 
                     // Summary content
-                    contentView
+                    VStack(alignment: .leading, spacing: DS.Spacing.xxs) {
+                        contentView
+
+                        // Word count & duration metrics
+                        if !content.isEmpty {
+                            let wordCount = WordCounter.count(in: content)
+                            if wordCount > 0 {
+                                let isCJK = WordCounter.isCJKDominant(content)
+                                if isOverall {
+                                    Text(WordCounter.formatWordCount(wordCount: wordCount, isCJK: isCJK))
+                                        .font(DS.Typography.caption2)
+                                        .foregroundStyle(.tertiary)
+                                } else {
+                                    let duration = coveringTo - coveringFrom
+                                    if duration > 0 {
+                                        Text(WordCounter.formatMetrics(
+                                            wordCount: wordCount,
+                                            duration: duration,
+                                            isCJK: isCJK
+                                        ))
+                                        .font(DS.Typography.caption2)
+                                        .foregroundStyle(.tertiary)
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
 

--- a/notetakerTests/WordCounterTests.swift
+++ b/notetakerTests/WordCounterTests.swift
@@ -1,0 +1,76 @@
+import Testing
+@testable import notetaker
+
+@Suite("WordCounter")
+struct WordCounterTests {
+    @Test func englishWordCount() {
+        #expect(WordCounter.count(in: "Hello world this is a test") == 6)
+    }
+
+    @Test func cjkCharCount() {
+        #expect(WordCounter.count(in: "今天讨论产品方案") == 8)
+    }
+
+    @Test func mixedContent() {
+        // CJK dominant: counts chars
+        let text = "今天讨论了 product roadmap"
+        let count = WordCounter.count(in: text)
+        #expect(count > 0)
+    }
+
+    @Test func emptyText() {
+        #expect(WordCounter.count(in: "") == 0)
+        #expect(WordCounter.count(in: "   ") == 0)
+    }
+
+    @Test func punctuationFiltered_cjk() {
+        // Punctuation should not count as words in CJK
+        #expect(WordCounter.count(in: "你好，世界！") == 4) // 你好世界, not 你好，世界！
+    }
+
+    @Test func formatMetrics_minutes() {
+        let result = WordCounter.formatMetrics(wordCount: 320, duration: 300)
+        #expect(result.contains("320"))
+        #expect(result.contains("5 min"))
+    }
+
+    @Test func formatMetrics_seconds() {
+        let result = WordCounter.formatMetrics(wordCount: 50, duration: 45)
+        #expect(result.contains("50"))
+        #expect(result.contains("45s"))
+    }
+
+    @Test func formatMetrics_cjk() {
+        let result = WordCounter.formatMetrics(wordCount: 200, duration: 180, isCJK: true)
+        #expect(result.contains("字"))
+    }
+
+    @Test func isCJKDominant_chinese() {
+        #expect(WordCounter.isCJKDominant("今天开会讨论产品"))
+    }
+
+    @Test func isCJKDominant_english() {
+        #expect(!WordCounter.isCJKDominant("Today we discussed the product"))
+    }
+
+    @Test func formatMetrics_minutesAndSeconds() {
+        let result = WordCounter.formatMetrics(wordCount: 100, duration: 150) // 2m 30s
+        #expect(result.contains("2m"))
+        #expect(result.contains("30s"))
+    }
+
+    @Test func formatWordCount_english() {
+        let result = WordCounter.formatWordCount(wordCount: 500)
+        #expect(result == "~500 words")
+    }
+
+    @Test func formatWordCount_singular() {
+        let result = WordCounter.formatWordCount(wordCount: 1)
+        #expect(result == "~1 word")
+    }
+
+    @Test func formatWordCount_cjk() {
+        let result = WordCounter.formatWordCount(wordCount: 200, isCJK: true)
+        #expect(result == "~200 字")
+    }
+}


### PR DESCRIPTION
## Summary
- WordCounter: CJK-aware counting, metrics formatting
- SummaryCardView metrics line below content
- 14 unit tests

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)