### PR TITLE
feat: global recording hotkey with customizable shortcut

### DIFF
--- a/UnitTests.xctestplan
+++ b/UnitTests.xctestplan
@@ -25,6 +25,7 @@
         "BufferFactoryTests",
         "FileAudioSourceTests",
         "FoundationModelsEngineTests",
+        "GlobalHotkeyTests",
         "LLMConfigCoverageTests",
         "LLMHTTPHelpersTests",
         "LLMModelProfileCoverageTests",

--- a/notetaker/Services/GlobalHotkeyService.swift
+++ b/notetaker/Services/GlobalHotkeyService.swift
@@ -1,0 +1,109 @@
+import Cocoa
+import os
+
+/// Manages a system-wide keyboard shortcut for toggling recording.
+@MainActor
+final class GlobalHotkeyService {
+    static let shared = GlobalHotkeyService()
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "notetaker", category: "GlobalHotkey")
+
+    /// Callback when hotkey is triggered
+    var onToggleRecording: (() -> Void)?
+
+    private var globalMonitor: Any?
+    private var localMonitor: Any?
+
+    // Default: Ctrl+Option+R
+    static let defaultKeyCode: UInt16 = 15 // R key
+    static let defaultModifiers: UInt = NSEvent.ModifierFlags([.control, .option]).rawValue
+
+    private init() {}
+
+    /// Register global and local hotkey monitors
+    func register() {
+        unregister() // Clear any existing monitors
+
+        guard UserDefaults.standard.bool(forKey: "globalHotkeyEnabled") else {
+            Self.logger.info("Global hotkey disabled, skipping registration")
+            return
+        }
+
+        let keyCode = UInt16(UserDefaults.standard.integer(forKey: "globalHotkeyKeyCode"))
+        let modRaw = UInt(UserDefaults.standard.integer(forKey: "globalHotkeyModifiers"))
+
+        // Use defaults if not configured
+        let targetKeyCode = keyCode == 0 ? Self.defaultKeyCode : keyCode
+        let targetMods = modRaw == 0 ? Self.defaultModifiers : modRaw
+        let targetModFlags = NSEvent.ModifierFlags(rawValue: targetMods).intersection(.deviceIndependentFlagsMask)
+
+        // Global monitor (when app is NOT focused)
+        globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            let eventMods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            if event.keyCode == targetKeyCode && eventMods == targetModFlags {
+                Task { @MainActor [weak self] in
+                    self?.onToggleRecording?()
+                }
+            }
+        }
+
+        // Local monitor (when app IS focused)
+        localMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            let eventMods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            if event.keyCode == targetKeyCode && eventMods == targetModFlags {
+                Task { @MainActor [weak self] in
+                    self?.onToggleRecording?()
+                }
+                return nil // Consume the event
+            }
+            return event
+        }
+
+        Self.logger.info("Global hotkey registered: keyCode=\(targetKeyCode), modifiers=\(targetMods)")
+    }
+
+    /// Unregister all monitors
+    func unregister() {
+        if let monitor = globalMonitor {
+            NSEvent.removeMonitor(monitor)
+            globalMonitor = nil
+        }
+        if let monitor = localMonitor {
+            NSEvent.removeMonitor(monitor)
+            localMonitor = nil
+        }
+    }
+}
+
+/// Utilities for displaying hotkey information
+nonisolated enum HotkeyDisplayHelper {
+    /// Convert modifier flags to display string (e.g., "⌃⌥")
+    static func modifierSymbols(_ rawValue: UInt) -> String {
+        let flags = NSEvent.ModifierFlags(rawValue: rawValue)
+        var symbols = ""
+        if flags.contains(.control) { symbols += "⌃" }
+        if flags.contains(.option) { symbols += "⌥" }
+        if flags.contains(.shift) { symbols += "⇧" }
+        if flags.contains(.command) { symbols += "⌘" }
+        return symbols
+    }
+
+    /// Convert key code to display name
+    static func keyName(for keyCode: UInt16) -> String {
+        let names: [UInt16: String] = [
+            0: "A", 1: "S", 2: "D", 3: "F", 4: "H", 5: "G", 6: "Z", 7: "X",
+            8: "C", 9: "V", 11: "B", 12: "Q", 13: "W", 14: "E", 15: "R",
+            16: "Y", 17: "T", 31: "O", 32: "U", 34: "I", 35: "P",
+            37: "L", 38: "J", 40: "K", 45: "N", 46: "M",
+            18: "1", 19: "2", 20: "3", 21: "4", 23: "5", 22: "6", 26: "7",
+            28: "8", 25: "9", 29: "0",
+            49: "Space", 36: "Return", 48: "Tab", 51: "Delete", 53: "Escape",
+            123: "←", 124: "→", 125: "↓", 126: "↑",
+        ]
+        return names[keyCode] ?? "Key\(keyCode)"
+    }
+
+    /// Full display string like "⌃⌥R"
+    static func displayString(keyCode: UInt16, modifiers: UInt) -> String {
+        modifierSymbols(modifiers) + keyName(for: keyCode)
+    }
+}

--- a/notetaker/Views/SettingsTab.swift
+++ b/notetaker/Views/SettingsTab.swift
@@ -216,10 +216,67 @@ struct SummarizationSettingsTab: View {
 
 struct RecordingSettingsTab: View {
     @AppStorage("vadConfigJSON") private var vadConfigJSON: String = ""
+    @AppStorage("globalHotkeyEnabled") private var globalHotkeyEnabled = true
+    @AppStorage("globalHotkeyKeyCode") private var hotkeyKeyCode = Int(GlobalHotkeyService.defaultKeyCode)
+    @AppStorage("globalHotkeyModifiers") private var hotkeyModifiers = Int(GlobalHotkeyService.defaultModifiers)
     @State private var config: VADConfig = .default
+    @State private var isRecordingHotkey = false
+    @State private var hotkeyMonitor: Any?
 
     var body: some View {
         SettingsGrid {
+            SettingsRow("Global Hotkey") {
+                Toggle("", isOn: $globalHotkeyEnabled)
+                    .labelsHidden()
+                    .help("Enable a system-wide keyboard shortcut to toggle recording.")
+                    .onChange(of: globalHotkeyEnabled) { _, _ in
+                        GlobalHotkeyService.shared.register()
+                    }
+            }
+
+            if globalHotkeyEnabled {
+                SettingsRow("Shortcut") {
+                    HStack(spacing: DS.Spacing.sm) {
+                        Button {
+                            if isRecordingHotkey {
+                                stopRecordingHotkey()
+                            } else {
+                                startRecordingHotkey()
+                            }
+                        } label: {
+                            if isRecordingHotkey {
+                                Text("Press shortcut…")
+                                    .foregroundStyle(.orange)
+                                    .font(DS.Typography.caption)
+                            } else {
+                                Text(HotkeyDisplayHelper.displayString(
+                                    keyCode: UInt16(hotkeyKeyCode),
+                                    modifiers: UInt(hotkeyModifiers)
+                                ))
+                                .font(.system(.body, design: .monospaced))
+                                .padding(.horizontal, DS.Spacing.sm)
+                                .padding(.vertical, DS.Spacing.xxs)
+                                .background(.quaternary)
+                                .clipShape(RoundedRectangle(cornerRadius: DS.Radius.sm))
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Recording hotkey: \(HotkeyDisplayHelper.displayString(keyCode: UInt16(hotkeyKeyCode), modifiers: UInt(hotkeyModifiers)))")
+
+                        Button("Reset") {
+                            hotkeyKeyCode = Int(GlobalHotkeyService.defaultKeyCode)
+                            hotkeyModifiers = Int(GlobalHotkeyService.defaultModifiers)
+                            GlobalHotkeyService.shared.register()
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(.secondary)
+                        .font(DS.Typography.caption)
+                    }
+                }
+            }
+
+            Divider()
+
             SettingsRow("Voice Activity Detection") {
                 Toggle("", isOn: $config.vadEnabled)
                     .labelsHidden()
@@ -260,9 +317,36 @@ struct RecordingSettingsTab: View {
                 }
             }
         }
+        .animation(.easeInOut(duration: 0.2), value: globalHotkeyEnabled)
+        .animation(.easeInOut(duration: 0.2), value: config.silenceTimeoutSeconds != nil)
         .onAppear { loadConfig() }
+        .onDisappear { stopRecordingHotkey() }
         .onChange(of: config) { _, newValue in saveConfig(newValue) }
         .settingsFooter("Changes take effect on next recording.", icon: "arrow.clockwise")
+    }
+
+    private func startRecordingHotkey() {
+        isRecordingHotkey = true
+        // Temporarily unregister the global hotkey so it doesn't fire while recording a new one
+        GlobalHotkeyService.shared.unregister()
+        hotkeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [self] event in
+            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            // Require at least one modifier key
+            guard !mods.isEmpty else { return event }
+            hotkeyKeyCode = Int(event.keyCode)
+            hotkeyModifiers = Int(mods.rawValue)
+            stopRecordingHotkey()
+            GlobalHotkeyService.shared.register()
+            return nil // Consume the event
+        }
+    }
+
+    private func stopRecordingHotkey() {
+        isRecordingHotkey = false
+        if let monitor = hotkeyMonitor {
+            NSEvent.removeMonitor(monitor)
+            hotkeyMonitor = nil
+        }
     }
 
     private func loadConfig() {

--- a/notetaker/notetakerApp.swift
+++ b/notetaker/notetakerApp.swift
@@ -22,6 +22,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Cancel all background summaries — don't wait for LLM responses
         BackgroundSummaryService.shared.cancelAll()
 
+        GlobalHotkeyService.shared.unregister()
+
         return .terminateNow
     }
 }
@@ -74,6 +76,34 @@ struct notetakerApp: App {
 
         // 3c: Auto-start is now handled directly by SchedulerViewModel.handleFire()
         // via direct callback to RecordingViewModel (no notification relay needed).
+
+        // Wire global hotkey to toggle recording
+        let hotkeyVM = vm
+        let hotkeyContainer = sharedModelContainer
+        GlobalHotkeyService.shared.onToggleRecording = { [weak hotkeyVM, weak hotkeyContainer] in
+            guard let vm = hotkeyVM else { return }
+            switch vm.state {
+            case .idle, .completed:
+                Task { @MainActor in
+                    await vm.startRecording(modelContext: hotkeyContainer?.mainContext)
+                }
+            case .recording, .paused:
+                vm.stopRecording(modelContext: hotkeyContainer?.mainContext)
+            case .stopping:
+                break // Ignore while stopping
+            }
+        }
+
+        // Set hotkey defaults if first launch
+        if UserDefaults.standard.object(forKey: "globalHotkeyEnabled") == nil {
+            UserDefaults.standard.set(true, forKey: "globalHotkeyEnabled")
+        }
+        if UserDefaults.standard.integer(forKey: "globalHotkeyKeyCode") == 0 {
+            UserDefaults.standard.set(Int(GlobalHotkeyService.defaultKeyCode), forKey: "globalHotkeyKeyCode")
+            UserDefaults.standard.set(Int(GlobalHotkeyService.defaultModifiers), forKey: "globalHotkeyModifiers")
+        }
+
+        GlobalHotkeyService.shared.register()
     }
 
     @ViewBuilder

--- a/notetakerTests/GlobalHotkeyTests.swift
+++ b/notetakerTests/GlobalHotkeyTests.swift
@@ -1,0 +1,106 @@
+import Testing
+import Cocoa
+@testable import notetaker
+
+@Suite("Global Hotkey")
+struct GlobalHotkeyTests {
+    @Test func modifierSymbols_controlOption() {
+        let mods = NSEvent.ModifierFlags([.control, .option]).rawValue
+        let symbols = HotkeyDisplayHelper.modifierSymbols(UInt(mods))
+        #expect(symbols.contains("⌃"))
+        #expect(symbols.contains("⌥"))
+    }
+
+    @Test func modifierSymbols_commandShift() {
+        let mods = NSEvent.ModifierFlags([.command, .shift]).rawValue
+        let symbols = HotkeyDisplayHelper.modifierSymbols(UInt(mods))
+        #expect(symbols.contains("⌘"))
+        #expect(symbols.contains("⇧"))
+    }
+
+    @Test func modifierSymbols_empty() {
+        #expect(HotkeyDisplayHelper.modifierSymbols(0) == "")
+    }
+
+    @Test func keyName_commonKeys() {
+        #expect(HotkeyDisplayHelper.keyName(for: 15) == "R")
+        #expect(HotkeyDisplayHelper.keyName(for: 0) == "A")
+        #expect(HotkeyDisplayHelper.keyName(for: 49) == "Space")
+        #expect(HotkeyDisplayHelper.keyName(for: 53) == "Escape")
+    }
+
+    @Test func keyName_unknownKey() {
+        #expect(HotkeyDisplayHelper.keyName(for: 255).hasPrefix("Key"))
+    }
+
+    @MainActor @Test func displayString_defaultHotkey() {
+        let display = HotkeyDisplayHelper.displayString(
+            keyCode: GlobalHotkeyService.defaultKeyCode,
+            modifiers: UInt(GlobalHotkeyService.defaultModifiers)
+        )
+        #expect(display.contains("R"))
+        #expect(display.contains("⌃"))
+        #expect(display.contains("⌥"))
+    }
+
+    @Test func displayString_format() {
+        let display = HotkeyDisplayHelper.displayString(
+            keyCode: 12,
+            modifiers: NSEvent.ModifierFlags.command.rawValue
+        )
+        #expect(display == "⌘Q")
+    }
+
+    @Test func modifierSymbols_order() {
+        // Should be ⌃⌥⇧⌘ order
+        let mods = NSEvent.ModifierFlags([.command, .control, .option, .shift]).rawValue
+        let symbols = HotkeyDisplayHelper.modifierSymbols(UInt(mods))
+        let controlIdx = symbols.firstIndex(of: "⌃")!
+        let optionIdx = symbols.firstIndex(of: "⌥")!
+        let shiftIdx = symbols.firstIndex(of: "⇧")!
+        let cmdIdx = symbols.firstIndex(of: "⌘")!
+        #expect(controlIdx < optionIdx)
+        #expect(optionIdx < shiftIdx)
+        #expect(shiftIdx < cmdIdx)
+    }
+
+    @Test func keyName_allLetters() {
+        #expect(HotkeyDisplayHelper.keyName(for: 1) == "S")
+        #expect(HotkeyDisplayHelper.keyName(for: 13) == "W")
+        #expect(HotkeyDisplayHelper.keyName(for: 46) == "M")
+    }
+
+    @Test func keyName_numbers() {
+        #expect(HotkeyDisplayHelper.keyName(for: 18) == "1")
+        #expect(HotkeyDisplayHelper.keyName(for: 29) == "0")
+    }
+
+    @Test func keyName_specialKeys() {
+        #expect(HotkeyDisplayHelper.keyName(for: 36) == "Return")
+        #expect(HotkeyDisplayHelper.keyName(for: 48) == "Tab")
+        #expect(HotkeyDisplayHelper.keyName(for: 51) == "Delete")
+    }
+
+    @Test func keyName_arrowKeys() {
+        #expect(HotkeyDisplayHelper.keyName(for: 123) == "←")
+        #expect(HotkeyDisplayHelper.keyName(for: 124) == "→")
+        #expect(HotkeyDisplayHelper.keyName(for: 125) == "↓")
+        #expect(HotkeyDisplayHelper.keyName(for: 126) == "↑")
+    }
+
+    @Test func modifierSymbols_singleModifier() {
+        #expect(HotkeyDisplayHelper.modifierSymbols(NSEvent.ModifierFlags.control.rawValue) == "⌃")
+        #expect(HotkeyDisplayHelper.modifierSymbols(NSEvent.ModifierFlags.option.rawValue) == "⌥")
+        #expect(HotkeyDisplayHelper.modifierSymbols(NSEvent.ModifierFlags.shift.rawValue) == "⇧")
+        #expect(HotkeyDisplayHelper.modifierSymbols(NSEvent.ModifierFlags.command.rawValue) == "⌘")
+    }
+
+    @MainActor @Test func defaultKeyCode_isR() {
+        #expect(GlobalHotkeyService.defaultKeyCode == 15)
+    }
+
+    @MainActor @Test func defaultModifiers_isControlOption() {
+        let expected = NSEvent.ModifierFlags([.control, .option]).rawValue
+        #expect(GlobalHotkeyService.defaultModifiers == expected)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `GlobalHotkeyService` singleton with NSEvent global+local monitors (default Ctrl+Option+R)
- Customizable shortcut via `HotkeyDisplayHelper` (nonisolated enum for testability)
- Settings UI toggle + shortcut recorder in `RecordingSettingsTab`
- 15 unit tests covering modifier symbols, key names, display strings

Closes #21

## Test plan
- [x] Build succeeds
- [x] 15 GlobalHotkeyTests pass
- [ ] Manual: toggle hotkey in Settings, verify Ctrl+Option+R starts/stops recording

🤖 Generated with [Claude Code](https://claude.com/claude-code)