### PR TITLE
feat: drag and drop session export

### DIFF
--- a/UnitTests.xctestplan
+++ b/UnitTests.xctestplan
@@ -20,6 +20,7 @@
       "selectedTests" : [
         "AudioConfigTests",
         "ChatServiceTests",
+        "DragDropExportTests",
         "AudioExporterTests",
         "AudioLevelMeterTests",
         "BufferFactoryTests",

--- a/notetaker/Services/SessionTransferableHelper.swift
+++ b/notetaker/Services/SessionTransferableHelper.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+import UniformTypeIdentifiers
+import os
+
+/// Lightweight value type carrying session data for export — no SwiftData dependency.
+nonisolated struct SessionExportInfo: Sendable {
+    let title: String
+    let startedAt: Date
+    let segments: [(startTime: TimeInterval, text: String)]
+    let summaryContent: String?
+
+    /// Format session as plain text with timestamped transcript.
+    func formatAsPlainText() -> String {
+        var lines: [String] = []
+        lines.append("# \(title)")
+        lines.append(startedAt.formatted(date: .abbreviated, time: .shortened))
+        lines.append("")
+
+        if let summaryContent, !summaryContent.isEmpty {
+            lines.append("## Summary")
+            lines.append(summaryContent)
+            lines.append("")
+        }
+
+        if !segments.isEmpty {
+            lines.append("## Transcript")
+            for segment in segments {
+                let time = formatTime(segment.startTime)
+                lines.append("\(time)  \(segment.text)")
+            }
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    private func formatTime(_ seconds: TimeInterval) -> String {
+        let total = Int(seconds)
+        let mins = total / 60
+        let secs = total % 60
+        return String(format: "%02d:%02d", mins, secs)
+    }
+
+    /// Sanitize title for use as filename.
+    func sanitizedFilename() -> String {
+        let cleaned = title
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+            .joined(separator: "_")
+        let limited = String(cleaned.prefix(80))
+        return limited.isEmpty ? "session" : limited
+    }
+}
+
+/// Transferable wrapper for dragging sessions out of the app.
+///
+/// Since `RecordingSession` is a SwiftData `@Model` (reference type with MainActor isolation),
+/// we snapshot data into `SessionExportInfo` and wrap it here for `Transferable` conformance.
+struct SessionExportItem: Transferable {
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "notetaker",
+        category: "SessionExportItem"
+    )
+
+    let info: SessionExportInfo
+
+    static var transferRepresentation: some TransferRepresentation {
+        // Plain text — drag to text fields, editors, etc.
+        DataRepresentation(exportedContentType: .plainText) { item in
+            Self.logger.info("Exporting plain text for session: \(item.info.title)")
+            let text = item.info.formatAsPlainText()
+            return Data(text.utf8)
+        }
+
+        // Text file — drag to Finder, file-accepting apps
+        FileRepresentation(exportedContentType: .utf8PlainText) { item in
+            let text = item.info.formatAsPlainText()
+            let filename = item.info.sanitizedFilename() + ".txt"
+            let tempURL = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent(filename)
+            try Data(text.utf8).write(to: tempURL)
+            Self.logger.info("Exported text file to: \(tempURL.path)")
+            return SentTransferredFile(tempURL)
+        }
+    }
+}
+
+// MARK: - Convenience initializer from RecordingSession
+
+extension SessionExportItem {
+    /// Create from a RecordingSession (must be called on MainActor).
+    @MainActor
+    init(session: RecordingSession) {
+        let sortedSegments = session.segments
+            .sorted { $0.startTime < $1.startTime }
+            .map { (startTime: $0.startTime, text: $0.text) }
+
+        let overallSummary = session.summaries
+            .filter(\.isOverall)
+            .first?
+            .displayContent
+
+        self.info = SessionExportInfo(
+            title: session.title,
+            startedAt: session.startedAt,
+            segments: sortedSegments,
+            summaryContent: overallSummary
+        )
+    }
+}

--- a/notetaker/Views/SessionListView.swift
+++ b/notetaker/Views/SessionListView.swift
@@ -128,6 +128,7 @@ struct SessionListView: View {
                     ForEach(group.sessions, id: \.id) { session in
                         SessionRowView(session: session)
                             .tag(session.id)
+                            .draggable(SessionExportItem(session: session))
                             .contextMenu {
                                 deleteButton(for: [session.id])
                             }

--- a/notetakerTests/DragDropExportTests.swift
+++ b/notetakerTests/DragDropExportTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Testing
+@testable import notetaker
+
+@Suite("DragDropExport")
+struct DragDropExportTests {
+
+    @Test func plainTextFormat_includesTitle() {
+        let item = SessionExportInfo(
+            title: "Test Meeting",
+            startedAt: Date(),
+            segments: [(startTime: 0, text: "Hello world")],
+            summaryContent: nil
+        )
+        let text = item.formatAsPlainText()
+        #expect(text.contains("# Test Meeting"))
+        #expect(text.contains("00:00  Hello world"))
+    }
+
+    @Test func plainTextFormat_includesSummary() {
+        let item = SessionExportInfo(
+            title: "Test",
+            startedAt: Date(),
+            segments: [],
+            summaryContent: "Meeting summary"
+        )
+        let text = item.formatAsPlainText()
+        #expect(text.contains("## Summary"))
+        #expect(text.contains("Meeting summary"))
+    }
+
+    @Test func plainTextFormat_emptyContent() {
+        let item = SessionExportInfo(
+            title: "Empty",
+            startedAt: Date(),
+            segments: [],
+            summaryContent: nil
+        )
+        let text = item.formatAsPlainText()
+        #expect(text.contains("# Empty"))
+        #expect(!text.contains("## Summary"))
+        #expect(!text.contains("## Transcript"))
+    }
+
+    @Test func plainTextFormat_multipleSegments() {
+        let item = SessionExportInfo(
+            title: "Multi",
+            startedAt: Date(),
+            segments: [
+                (startTime: 0, text: "First"),
+                (startTime: 60, text: "Second"),
+                (startTime: 125, text: "Third"),
+            ],
+            summaryContent: nil
+        )
+        let text = item.formatAsPlainText()
+        #expect(text.contains("00:00  First"))
+        #expect(text.contains("01:00  Second"))
+        #expect(text.contains("02:05  Third"))
+    }
+
+    @Test func timeFormatting_largeValues() {
+        let item = SessionExportInfo(
+            title: "T",
+            startedAt: Date(),
+            segments: [(startTime: 3661, text: "Late")],
+            summaryContent: nil
+        )
+        let text = item.formatAsPlainText()
+        // 3661 seconds = 61 min 1 sec
+        #expect(text.contains("61:01  Late"))
+    }
+
+    @Test func plainTextFormat_summaryAndTranscript() {
+        let item = SessionExportInfo(
+            title: "Full Session",
+            startedAt: Date(),
+            segments: [
+                (startTime: 0, text: "Hello"),
+                (startTime: 30, text: "World"),
+            ],
+            summaryContent: "A brief discussion"
+        )
+        let text = item.formatAsPlainText()
+        #expect(text.contains("# Full Session"))
+        #expect(text.contains("## Summary"))
+        #expect(text.contains("A brief discussion"))
+        #expect(text.contains("## Transcript"))
+        #expect(text.contains("00:00  Hello"))
+        #expect(text.contains("00:30  World"))
+    }
+
+    @Test func plainTextFormat_emptySummaryExcluded() {
+        let item = SessionExportInfo(
+            title: "No Summary",
+            startedAt: Date(),
+            segments: [(startTime: 0, text: "Words")],
+            summaryContent: ""
+        )
+        let text = item.formatAsPlainText()
+        #expect(!text.contains("## Summary"))
+    }
+
+    @Test func plainTextFormat_dateIncluded() {
+        let date = Date(timeIntervalSince1970: 0)
+        let item = SessionExportInfo(
+            title: "Dated",
+            startedAt: date,
+            segments: [],
+            summaryContent: nil
+        )
+        let text = item.formatAsPlainText()
+        // Date should appear on second line (formatted)
+        let lines = text.components(separatedBy: "\n")
+        #expect(lines.count >= 2)
+        #expect(!lines[1].isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- `SessionExportItem: Transferable` with DataRepresentation (plain text) + FileRepresentation (.txt file)
- Self-contained `SessionExportInfo` struct (no dependency on MarkdownExporter or other PRs)
- Simple text format: title, date, summary section, timestamped transcript
- Minimal SessionListView change (single `.draggable()` modifier on rows)
- 8 unit tests

Closes #28

## Test plan
- [x] Build succeeds
- [x] 8 DragDropExportTests pass
- [ ] Manual: drag session row to Finder/TextEdit, verify exported content

🤖 Generated with [Claude Code](https://claude.com/claude-code)