### PR TITLE
feat: App Intents for Shortcuts & Siri integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,13 @@ xcodebuild -scheme notetaker -configuration Debug -only-testing:notetakerUITests
 - **Recurrence mapping**: `CalendarService.mapRecurrenceRule()` maps `EKRecurrenceRule` to `RepeatRule`; only `interval == 1`; weekday detection via `Set<EKWeekday>` equality
 - **SchemaV6**: Adds `calendarEventIdentifier: String? = nil` to `ScheduledRecording`, `scheduledRecordingID: UUID? = nil` to `RecordingSession`
 
+### App Intents & Shortcuts
+- **`AppIntentState`**: `@MainActor` singleton bridge — holds weak `RecordingViewModel` ref and optional `ModelContainer`; wired in `notetakerApp.init()`; `ensureReady()` throws `AppIntentError.appNotRunning` if not configured
+- **4 intents**: `StartRecordingIntent` (openAppWhenRun, optional title), `StopRecordingIntent`, `GetLastSummaryIntent` (optional SessionEntity param, falls back to most recent), `SearchTranscriptsIntent` (returns `[SessionEntity]`)
+- **`SessionEntity`**: `AppEntity` with `SessionEntityQuery`; `id` is `String` (UUID); date maps to `RecordingSession.startedAt`; `suggestedEntities()` returns 10 most recent
+- **`NotetakerShortcuts`**: `AppShortcutsProvider` with Siri phrases; `String` parameters cannot be referenced in phrases (only `AppEntity`/`AppEnum` allowed)
+- **Testing**: `AppIntentError` name collides with `AppIntents` framework — use `notetaker.AppIntentError` typealias in tests; `DisplayRepresentation.title` uses string interpolation so direct `==` comparison with string literals fails
+
 ## Architecture
 
 Three-layer architecture: Views → ViewModels → Services, with SwiftData `@Model` classes for persistence.
@@ -143,6 +150,7 @@ Three-layer architecture: Views → ViewModels → Services, with SwiftData `@Mo
   - `ViewModels/` — `RecordingViewModel` (`@Observable`) — central state machine for recording lifecycle; `SchedulerViewModel` — scheduled recordings + calendar integration
   - `DesignSystem.swift` — `DS` enum (spacing, typography, colors, radius, layout tokens)
   - `Views/` — SwiftUI views including `SettingsView` (4-tab layout: `SettingsTab`, `ModelsSettingsTab`, `AboutTab`), `ScheduleView`, `ScheduleEditorView`, `PrivacyDisclosureView`, `SummaryCardView`, `TranscriptSegmentRow`, `AudioLevelBar`, `ResizeHandle`, `VerticalResizeHandle`, `ChatView`, `SettingsComponents` (reusable settings UI), `ViewModifiers`
+  - `Intents/` — App Intents for Shortcuts & Siri: `AppIntentState` (singleton bridge), `StartRecordingIntent`, `StopRecordingIntent`, `GetLastSummaryIntent`, `SearchTranscriptsIntent`, `NotetakerShortcuts` (AppShortcutsProvider), `Entities/SessionEntity` (AppEntity + EntityQuery)
 - **`notetakerTests/`** — Swift Testing (`@Test`, `#expect`); ~64 test files; `Mocks/` has `MockASREngine`, `MockLLMEngine`, `MockSchedulerService`, per-suite `MockURLProtocol` subclasses; `Helpers/` has `BufferFactory` and `FileAudioSource`
 - **`notetakerUITests/`** — XCTest UI tests (light/dark mode via `runsForEachTargetApplicationUIConfiguration`)
 - **`scripts/`** — `increment_build_number.sh`

--- a/UnitTests.xctestplan
+++ b/UnitTests.xctestplan
@@ -18,6 +18,7 @@
         "name" : "notetakerTests"
       },
       "selectedTests" : [
+        "AppIntentsTests",
         "AudioConfigTests",
         "ChatServiceTests",
         "AudioExporterTests",

--- a/notetaker/Intents/AppIntentState.swift
+++ b/notetaker/Intents/AppIntentState.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+import SwiftData
+import os
+
+/// Bridge for App Intents to access the running app's state.
+@MainActor
+final class AppIntentState {
+    static let shared = AppIntentState()
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "notetaker", category: "AppIntentState")
+
+    weak var viewModel: RecordingViewModel?
+    var modelContainerRef: ModelContainer?
+
+    private init() {}
+
+    func ensureReady() throws {
+        guard viewModel != nil, modelContainerRef != nil else {
+            Self.logger.error("AppIntentState not configured — app may not be running")
+            throw AppIntentError.appNotRunning
+        }
+    }
+}
+
+enum AppIntentError: Error, CustomLocalizedStringResourceConvertible {
+    case appNotRunning
+    case noActiveRecording
+    case noSessionFound
+
+    var localizedStringResource: LocalizedStringResource {
+        switch self {
+        case .appNotRunning: "Notetaker is not running"
+        case .noActiveRecording: "No active recording"
+        case .noSessionFound: "No session found"
+        }
+    }
+}

--- a/notetaker/Intents/Entities/SessionEntity.swift
+++ b/notetaker/Intents/Entities/SessionEntity.swift
@@ -1,0 +1,66 @@
+import AppIntents
+import SwiftData
+
+struct SessionEntity: AppEntity {
+    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Recording Session")
+    static var defaultQuery = SessionEntityQuery()
+
+    var id: String  // UUID string from RecordingSession
+    var title: String
+    var date: Date
+    var segmentCount: Int
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(
+            title: "\(title)",
+            subtitle: "\(date.formatted(date: .abbreviated, time: .shortened))"
+        )
+    }
+}
+
+struct SessionEntityQuery: EntityQuery {
+    func entities(for identifiers: [String]) async throws -> [SessionEntity] {
+        try await MainActor.run {
+            try AppIntentState.shared.ensureReady()
+            guard let container = AppIntentState.shared.modelContainerRef else { return [] }
+            let context = ModelContext(container)
+            var results: [SessionEntity] = []
+            for idStr in identifiers {
+                guard let uuid = UUID(uuidString: idStr) else { continue }
+                let predicate = #Predicate<RecordingSession> { $0.id == uuid }
+                var descriptor = FetchDescriptor(predicate: predicate)
+                descriptor.fetchLimit = 1
+                if let session = try context.fetch(descriptor).first {
+                    results.append(SessionEntity(
+                        id: session.id.uuidString,
+                        title: session.title,
+                        date: session.startedAt,
+                        segmentCount: session.segments.count
+                    ))
+                }
+            }
+            return results
+        }
+    }
+
+    func suggestedEntities() async throws -> [SessionEntity] {
+        try await MainActor.run {
+            try AppIntentState.shared.ensureReady()
+            guard let container = AppIntentState.shared.modelContainerRef else { return [] }
+            let context = ModelContext(container)
+            var descriptor = FetchDescriptor<RecordingSession>(
+                sortBy: [SortDescriptor(\.startedAt, order: .reverse)]
+            )
+            descriptor.fetchLimit = 10
+            let sessions = try context.fetch(descriptor)
+            return sessions.map { session in
+                SessionEntity(
+                    id: session.id.uuidString,
+                    title: session.title,
+                    date: session.startedAt,
+                    segmentCount: session.segments.count
+                )
+            }
+        }
+    }
+}

--- a/notetaker/Intents/GetLastSummaryIntent.swift
+++ b/notetaker/Intents/GetLastSummaryIntent.swift
@@ -1,0 +1,68 @@
+import AppIntents
+import SwiftData
+import os
+
+struct GetLastSummaryIntent: AppIntent {
+    static var title: LocalizedStringResource = "Get Meeting Summary"
+    static var description = IntentDescription("Get the summary of a recording session")
+
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "notetaker", category: "GetLastSummaryIntent")
+
+    @Parameter(title: "Session")
+    var session: SessionEntity?
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ReturnsValue<String> & ProvidesDialog {
+        Self.logger.info("GetLastSummaryIntent triggered")
+        try AppIntentState.shared.ensureReady()
+        guard let container = AppIntentState.shared.modelContainerRef else {
+            throw AppIntentError.appNotRunning
+        }
+
+        let context = container.mainContext
+        let targetSession: RecordingSession
+
+        if let sessionEntity = session, let uuid = UUID(uuidString: sessionEntity.id) {
+            let predicate = #Predicate<RecordingSession> { $0.id == uuid }
+            var descriptor = FetchDescriptor(predicate: predicate)
+            descriptor.fetchLimit = 1
+            guard let found = try context.fetch(descriptor).first else {
+                throw AppIntentError.noSessionFound
+            }
+            targetSession = found
+        } else {
+            // Get most recent session
+            var descriptor = FetchDescriptor<RecordingSession>(
+                sortBy: [SortDescriptor(\.startedAt, order: .reverse)]
+            )
+            descriptor.fetchLimit = 1
+            guard let last = try context.fetch(descriptor).first else {
+                throw AppIntentError.noSessionFound
+            }
+            targetSession = last
+        }
+
+        // Find overall summary
+        let sessionID = targetSession.id
+        let summaryPredicate = #Predicate<SummaryBlock> {
+            $0.session?.id == sessionID && $0.isOverall == true
+        }
+        let summaryDescriptor = FetchDescriptor(predicate: summaryPredicate)
+        let summaries = try context.fetch(summaryDescriptor)
+
+        if let summary = summaries.first {
+            let content = summary.displayContent
+            Self.logger.info("Returning summary for session '\(targetSession.title)'")
+            return .result(
+                value: content,
+                dialog: "\(targetSession.title): \(String(content.prefix(200)))"
+            )
+        } else {
+            Self.logger.info("No summary found for session '\(targetSession.title)'")
+            return .result(
+                value: "No summary available for this session.",
+                dialog: "No summary found for \(targetSession.title)"
+            )
+        }
+    }
+}

--- a/notetaker/Intents/NotetakerShortcuts.swift
+++ b/notetaker/Intents/NotetakerShortcuts.swift
@@ -1,0 +1,45 @@
+import AppIntents
+
+struct NotetakerShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: StartRecordingIntent(),
+            phrases: [
+                "Start recording with \(.applicationName)",
+                "Begin meeting recording in \(.applicationName)"
+            ],
+            shortTitle: "Start Recording",
+            systemImageName: "record.circle"
+        )
+
+        AppShortcut(
+            intent: StopRecordingIntent(),
+            phrases: [
+                "Stop recording with \(.applicationName)",
+                "End meeting recording in \(.applicationName)"
+            ],
+            shortTitle: "Stop Recording",
+            systemImageName: "stop.circle"
+        )
+
+        AppShortcut(
+            intent: GetLastSummaryIntent(),
+            phrases: [
+                "Get meeting summary from \(.applicationName)",
+                "Summarize last meeting with \(.applicationName)"
+            ],
+            shortTitle: "Get Summary",
+            systemImageName: "doc.text"
+        )
+
+        AppShortcut(
+            intent: SearchTranscriptsIntent(),
+            phrases: [
+                "Search transcripts in \(.applicationName)",
+                "Find in recordings with \(.applicationName)"
+            ],
+            shortTitle: "Search Transcripts",
+            systemImageName: "magnifyingglass"
+        )
+    }
+}

--- a/notetaker/Intents/SearchTranscriptsIntent.swift
+++ b/notetaker/Intents/SearchTranscriptsIntent.swift
@@ -1,0 +1,59 @@
+import AppIntents
+import SwiftData
+import os
+
+struct SearchTranscriptsIntent: AppIntent {
+    static var title: LocalizedStringResource = "Search Transcripts"
+    static var description = IntentDescription("Search across all recording transcripts")
+
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "notetaker", category: "SearchTranscriptsIntent")
+
+    @Parameter(title: "Search Query")
+    var query: String
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ReturnsValue<[SessionEntity]> & ProvidesDialog {
+        Self.logger.info("SearchTranscriptsIntent triggered, query='\(query)'")
+        try AppIntentState.shared.ensureReady()
+        guard let container = AppIntentState.shared.modelContainerRef else {
+            throw AppIntentError.appNotRunning
+        }
+
+        let context = container.mainContext
+        let searchQuery = query
+
+        // Search transcript segments
+        let segmentPredicate = #Predicate<TranscriptSegment> {
+            $0.text.localizedStandardContains(searchQuery)
+        }
+        let segments = try context.fetch(FetchDescriptor(predicate: segmentPredicate))
+
+        // Collect unique sessions
+        var sessionIDs = Set<UUID>()
+        var sessions: [RecordingSession] = []
+        for segment in segments {
+            if let session = segment.session, !sessionIDs.contains(session.id) {
+                sessionIDs.insert(session.id)
+                sessions.append(session)
+            }
+        }
+
+        // Sort by date descending
+        sessions.sort { $0.startedAt > $1.startedAt }
+
+        let entities = sessions.prefix(10).map { session in
+            SessionEntity(
+                id: session.id.uuidString,
+                title: session.title,
+                date: session.startedAt,
+                segmentCount: session.segments.count
+            )
+        }
+
+        Self.logger.info("Search found \(sessions.count) session(s) for query '\(query)'")
+        return .result(
+            value: Array(entities),
+            dialog: "Found \(sessions.count) session(s) matching \"\(query)\""
+        )
+    }
+}

--- a/notetaker/Intents/StartRecordingIntent.swift
+++ b/notetaker/Intents/StartRecordingIntent.swift
@@ -1,0 +1,42 @@
+import AppIntents
+import SwiftData
+import os
+
+struct StartRecordingIntent: AppIntent {
+    static var title: LocalizedStringResource = "Start Recording"
+    static var description = IntentDescription("Start a new recording session in Notetaker")
+    static var openAppWhenRun = true  // App must be running for audio capture
+
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "notetaker", category: "StartRecordingIntent")
+
+    @Parameter(title: "Title")
+    var sessionTitle: String?
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Start recording with title \(\.$sessionTitle)")
+    }
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        Self.logger.info("StartRecordingIntent triggered, title=\(sessionTitle ?? "<none>")")
+        try AppIntentState.shared.ensureReady()
+        guard let vm = AppIntentState.shared.viewModel,
+              let container = AppIntentState.shared.modelContainerRef else {
+            throw AppIntentError.appNotRunning
+        }
+
+        guard vm.state == .idle || vm.state == .completed else {
+            Self.logger.warning("Cannot start — already recording (state=\(String(describing: vm.state)))")
+            return .result(dialog: "Recording is already in progress")
+        }
+
+        await vm.startRecording(modelContext: container.mainContext)
+
+        if let title = sessionTitle, !title.isEmpty, let session = vm.currentSession {
+            session.title = title
+        }
+
+        Self.logger.info("Recording started via App Intent")
+        return .result(dialog: "Recording started")
+    }
+}

--- a/notetaker/Intents/StopRecordingIntent.swift
+++ b/notetaker/Intents/StopRecordingIntent.swift
@@ -1,0 +1,30 @@
+import AppIntents
+import SwiftData
+import os
+
+struct StopRecordingIntent: AppIntent {
+    static var title: LocalizedStringResource = "Stop Recording"
+    static var description = IntentDescription("Stop the current recording and save it")
+
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "notetaker", category: "StopRecordingIntent")
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        Self.logger.info("StopRecordingIntent triggered")
+        try AppIntentState.shared.ensureReady()
+        guard let vm = AppIntentState.shared.viewModel,
+              let container = AppIntentState.shared.modelContainerRef else {
+            throw AppIntentError.appNotRunning
+        }
+
+        guard vm.isActive else {
+            Self.logger.warning("No active recording to stop")
+            throw AppIntentError.noActiveRecording
+        }
+
+        vm.stopRecording(modelContext: container.mainContext)
+
+        Self.logger.info("Recording stopped via App Intent")
+        return .result(dialog: "Recording stopped and saved")
+    }
+}

--- a/notetaker/notetakerApp.swift
+++ b/notetaker/notetakerApp.swift
@@ -72,6 +72,10 @@ struct notetakerApp: App {
         appDelegate.schedulerViewModel = schedulerVM
         appDelegate.modelContainer = sharedModelContainer
 
+        // Wire App Intents state so Shortcuts/Siri can access the running app
+        AppIntentState.shared.viewModel = vm
+        AppIntentState.shared.modelContainerRef = sharedModelContainer
+
         // 3c: Auto-start is now handled directly by SchedulerViewModel.handleFire()
         // via direct callback to RecordingViewModel (no notification relay needed).
     }

--- a/notetakerTests/AppIntentsTests.swift
+++ b/notetakerTests/AppIntentsTests.swift
@@ -1,0 +1,111 @@
+import Testing
+import Foundation
+import AppIntents
+@testable import notetaker
+
+private typealias NotetakerError = notetaker.AppIntentError
+
+@Suite("AppIntentsTests")
+struct AppIntentsTests {
+
+    // MARK: - AppIntentError
+
+    @Test("AppIntentError has correct localized descriptions")
+    func errorDescriptions() {
+        let appNotRunning = NotetakerError.appNotRunning
+        let noActive = NotetakerError.noActiveRecording
+        let noSession = NotetakerError.noSessionFound
+
+        #expect(appNotRunning.localizedStringResource.key == "Notetaker is not running")
+        #expect(noActive.localizedStringResource.key == "No active recording")
+        #expect(noSession.localizedStringResource.key == "No session found")
+    }
+
+    @Test("AppIntentError conforms to Error")
+    func errorConformance() {
+        let error: any Error = NotetakerError.appNotRunning
+        #expect(error is NotetakerError)
+    }
+
+    // MARK: - SessionEntity
+
+    @Test("SessionEntity stores correct properties")
+    func sessionEntityProperties() {
+        let date = Date()
+        let entity = SessionEntity(
+            id: "550e8400-e29b-41d4-a716-446655440000",
+            title: "Team Standup",
+            date: date,
+            segmentCount: 42
+        )
+
+        #expect(entity.id == "550e8400-e29b-41d4-a716-446655440000")
+        #expect(entity.title == "Team Standup")
+        #expect(entity.date == date)
+        #expect(entity.segmentCount == 42)
+    }
+
+    @Test("SessionEntity display representation is not nil")
+    func sessionEntityDisplayRepresentation() {
+        let date = Date()
+        let entity = SessionEntity(
+            id: UUID().uuidString,
+            title: "Sprint Review",
+            date: date,
+            segmentCount: 10
+        )
+
+        // DisplayRepresentation uses string interpolation so title key is "%@"
+        // Just verify it can be constructed without crashing
+        let display = entity.displayRepresentation
+        #expect(display.subtitle != nil)
+    }
+
+    @Test("SessionEntity type display representation has correct name")
+    func sessionEntityTypeRepresentation() {
+        let typeRep = SessionEntity.typeDisplayRepresentation
+        #expect(typeRep.name == "Recording Session")
+    }
+
+    // MARK: - Intent metadata
+
+    @Test("StartRecordingIntent has correct metadata")
+    func startRecordingMetadata() {
+        #expect(StartRecordingIntent.title == "Start Recording")
+        #expect(StartRecordingIntent.openAppWhenRun == true)
+    }
+
+    @Test("StopRecordingIntent has correct metadata")
+    func stopRecordingMetadata() {
+        #expect(StopRecordingIntent.title == "Stop Recording")
+    }
+
+    @Test("GetLastSummaryIntent has correct metadata")
+    func getLastSummaryMetadata() {
+        #expect(GetLastSummaryIntent.title == "Get Meeting Summary")
+    }
+
+    @Test("SearchTranscriptsIntent has correct metadata")
+    func searchTranscriptsMetadata() {
+        #expect(SearchTranscriptsIntent.title == "Search Transcripts")
+    }
+
+    // MARK: - AppIntentState
+
+    @MainActor @Test("AppIntentState.ensureReady throws when not configured")
+    func ensureReadyThrows() {
+        let state = AppIntentState.shared
+        let savedVM = state.viewModel
+        let savedContainer = state.modelContainerRef
+        defer {
+            state.viewModel = savedVM
+            state.modelContainerRef = savedContainer
+        }
+        state.viewModel = nil
+        state.modelContainerRef = nil
+
+        #expect(throws: NotetakerError.self) {
+            try state.ensureReady()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 4 App Intents: StartRecording, StopRecording, GetLastSummary, SearchTranscripts
- SessionEntity as AppEntity with EntityQuery for Shortcuts integration
- AppShortcutsProvider with Siri phrases (English)
- AppIntentState singleton bridges Intent <-> App state
- 10 unit tests for intent metadata, entity properties, error handling

Closes #40

## Test plan
- [x] Build succeeds (`CODE_SIGNING_ALLOWED=NO`)
- [x] Unit tests pass (10/10 AppIntentsTests)
- [ ] Manual: open Shortcuts app, verify Notetaker intents appear
- [ ] Manual: "Hey Siri, start recording with Notetaker"

🤖 Generated with [Claude Code](https://claude.com/claude-code)