### PR TITLE
feat: auto-export pipeline for post-recording automation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,15 @@ xcodebuild -scheme notetaker -configuration Debug -only-testing:notetakerUITests
 - **Recurrence mapping**: `CalendarService.mapRecurrenceRule()` maps `EKRecurrenceRule` to `RepeatRule`; only `interval == 1`; weekday detection via `Set<EKWeekday>` equality
 - **SchemaV6**: Adds `calendarEventIdentifier: String? = nil` to `ScheduledRecording`, `scheduledRecordingID: UUID? = nil` to `RecordingSession`
 
+### Auto-Export Pipeline
+- **`AutoExportConfig`**: `nonisolated Sendable Codable` config stored as JSON in `@AppStorage("autoExportConfig")`; `isEnabled` toggle + ordered `[ExportAction]` list
+- **`ExportAction`**: enum with `.writeFile(WriteFileOptions)`, `.copyTranscript`, `.webhook(WebhookOptions)` — each action executes independently (one failure doesn't stop others)
+- **`AutoExportService`**: `nonisolated enum` — pure formatting helpers (`formatAsText`, `formatTimestamp`, `formatDate`, `formatDuration`, `interpolateFilename`) + action executors; injectable `URLSession` for webhook testing
+- **`ExportSessionInfo`**: lightweight `Sendable` struct decoupling export from SwiftData; carries title, date, duration, segments, overallSummary
+- **Integration**: `BackgroundSummaryService.triggerAutoExport()` fires after summary + title generation complete (both success and error paths); re-fetches session from context for fresh data
+- **Settings**: `AutoExportSettingsTab` in Settings > Export tab; uses `SettingsGrid`/`SettingsRow` components; `NSOpenPanel` for directory selection; webhook config with URL/method/auth/include toggles
+- **Filename template**: `{{title}}` and `{{date}}` placeholders; title sanitized (slashes/colons replaced with dashes); output as `.md` files
+
 ## Architecture
 
 Three-layer architecture: Views → ViewModels → Services, with SwiftData `@Model` classes for persistence.
@@ -138,11 +147,11 @@ Three-layer architecture: Views → ViewModels → Services, with SwiftData `@Mo
 - **`notetaker/`** — Main app target
   - `notetakerApp.swift` — Entry point, shared `ModelContainer`, `MenuBarExtra`, `Settings` scene
   - `ContentView.swift` — `NavigationSplitView` (sidebar session list + detail routing)
-  - `Models/` — SwiftData models (`RecordingSession`, `TranscriptSegment`, `SummaryBlock`, `ScheduledRecording`), config types (`LLMConfig`, `SummarizerConfig`, `LLMModelProfile`, `VADConfig`, `OverallSummaryMode`, `RepeatRule`), ephemeral types (`ChatMessage`), schema versioning (`Schemas/` V1–V6)
-  - `Services/` — Protocol-based engines (`ASREngine`, `LLMEngine`) with multiple implementations (including `FoundationModelsEngine` for Apple Intelligence), `AudioCaptureService`, `AudioPlaybackService`, `AudioExporter`, `SummarizerService`, `BackgroundSummaryService`, `SummaryMarkdownFormatter`, `ChatService`, `PromptBuilder`, `KeychainService`, `CrashLogService`, `SchedulerService`, `CalendarService`
+  - `Models/` — SwiftData models (`RecordingSession`, `TranscriptSegment`, `SummaryBlock`, `ScheduledRecording`), config types (`LLMConfig`, `SummarizerConfig`, `LLMModelProfile`, `VADConfig`, `OverallSummaryMode`, `RepeatRule`, `AutoExportConfig`), ephemeral types (`ChatMessage`), schema versioning (`Schemas/` V1–V6)
+  - `Services/` — Protocol-based engines (`ASREngine`, `LLMEngine`) with multiple implementations (including `FoundationModelsEngine` for Apple Intelligence), `AudioCaptureService`, `AudioPlaybackService`, `AudioExporter`, `SummarizerService`, `BackgroundSummaryService`, `SummaryMarkdownFormatter`, `ChatService`, `PromptBuilder`, `KeychainService`, `CrashLogService`, `SchedulerService`, `CalendarService`, `AutoExportService`
   - `ViewModels/` — `RecordingViewModel` (`@Observable`) — central state machine for recording lifecycle; `SchedulerViewModel` — scheduled recordings + calendar integration
   - `DesignSystem.swift` — `DS` enum (spacing, typography, colors, radius, layout tokens)
-  - `Views/` — SwiftUI views including `SettingsView` (4-tab layout: `SettingsTab`, `ModelsSettingsTab`, `AboutTab`), `ScheduleView`, `ScheduleEditorView`, `PrivacyDisclosureView`, `SummaryCardView`, `TranscriptSegmentRow`, `AudioLevelBar`, `ResizeHandle`, `VerticalResizeHandle`, `ChatView`, `SettingsComponents` (reusable settings UI), `ViewModifiers`
+  - `Views/` — SwiftUI views including `SettingsView` (6-tab layout: `SettingsTab`, `ModelsSettingsTab`, `AutoExportSettingsTab`, `AboutTab`), `ScheduleView`, `ScheduleEditorView`, `PrivacyDisclosureView`, `SummaryCardView`, `TranscriptSegmentRow`, `AudioLevelBar`, `ResizeHandle`, `VerticalResizeHandle`, `ChatView`, `SettingsComponents` (reusable settings UI), `ViewModifiers`
 - **`notetakerTests/`** — Swift Testing (`@Test`, `#expect`); ~64 test files; `Mocks/` has `MockASREngine`, `MockLLMEngine`, `MockSchedulerService`, per-suite `MockURLProtocol` subclasses; `Helpers/` has `BufferFactory` and `FileAudioSource`
 - **`notetakerUITests/`** — XCTest UI tests (light/dark mode via `runsForEachTargetApplicationUIConfiguration`)
 - **`scripts/`** — `increment_build_number.sh`
@@ -164,7 +173,7 @@ Three-layer architecture: Views → ViewModels → Services, with SwiftData `@Mo
 - **Close the app before running tests** — if the app is already running, UI tests attach to the existing instance instead of launching a fresh one, causing `Failed to terminate` errors and test failures
 - **Two-tier test plans**: `UnitTests.xctestplan` (22 pure-logic suites, ~257 tests, <0.2s) is default for Cmd+U; `FullTests.xctestplan` (all suites + UI tests) for CI on PR to main; shared scheme at `xcshareddata/xcschemes/notetaker.xcscheme` associates both plans
 - **Test plan gotcha**: Xcode auto-generated schemes don't support `-testPlan`; the explicit shared scheme with `shouldAutocreateTestPlan = "NO"` is required; verify with `xcodebuild -scheme notetaker -showTestPlans`
-- 31 test suites use `.serialized` to prevent parallel UserDefaults/Keychain/URLProtocol/SwiftData/NSPasteboard contamination; ~746 tests total across ~64 test files; UnitTests plan excludes all serialized suites for fast local iteration
+- 32 test suites use `.serialized` to prevent parallel UserDefaults/Keychain/URLProtocol/SwiftData/NSPasteboard contamination; ~771 tests total across ~65 test files; UnitTests plan excludes all serialized suites for fast local iteration
 
 ## CI Workflows
 

--- a/notetaker/Models/AutoExportConfig.swift
+++ b/notetaker/Models/AutoExportConfig.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Configuration for the auto-export pipeline that runs after recording + summary complete.
+nonisolated struct AutoExportConfig: Codable, Sendable, Equatable {
+    var isEnabled: Bool = false
+    var actions: [ExportAction] = []
+
+    static func fromUserDefaults() -> AutoExportConfig {
+        guard let data = UserDefaults.standard.data(forKey: "autoExportConfig"),
+              let config = try? JSONDecoder().decode(AutoExportConfig.self, from: data) else {
+            return AutoExportConfig()
+        }
+        return config
+    }
+
+    func saveToUserDefaults() {
+        if let data = try? JSONEncoder().encode(self) {
+            UserDefaults.standard.set(data, forKey: "autoExportConfig")
+        }
+    }
+}
+
+nonisolated enum ExportAction: Codable, Sendable, Equatable, Identifiable {
+    case writeFile(WriteFileOptions)
+    case copyTranscript
+    case webhook(WebhookOptions)
+
+    var id: String {
+        switch self {
+        case .writeFile: return "writeFile"
+        case .copyTranscript: return "copyTranscript"
+        case .webhook: return "webhook"
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .writeFile: return "Write to File"
+        case .copyTranscript: return "Copy Transcript"
+        case .webhook: return "Send Webhook"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .writeFile: return "doc.text"
+        case .copyTranscript: return "doc.on.clipboard"
+        case .webhook: return "arrow.up.forward.app"
+        }
+    }
+}
+
+nonisolated struct WriteFileOptions: Codable, Sendable, Equatable {
+    var directoryPath: String = ""
+    var filenameTemplate: String = "{{title}}_{{date}}"
+    var includeTranscript: Bool = true
+    var includeSummary: Bool = true
+}
+
+nonisolated struct WebhookOptions: Codable, Sendable, Equatable {
+    var url: String = ""
+    var method: String = "POST"
+    var includeTranscript: Bool = true
+    var includeSummary: Bool = true
+    var secretHeader: String = ""
+}

--- a/notetaker/Services/AutoExportService.swift
+++ b/notetaker/Services/AutoExportService.swift
@@ -1,0 +1,200 @@
+import AppKit
+import Foundation
+import os
+
+/// Lightweight data carrier for auto-export (no SwiftData dependency).
+nonisolated struct ExportSessionInfo: Sendable {
+    let title: String
+    let date: Date
+    let duration: TimeInterval
+    let segments: [(startTime: TimeInterval, text: String)]
+    let overallSummary: String?
+}
+
+/// Result of a single export action.
+nonisolated struct ExportResult: Sendable {
+    let actionID: String
+    let success: Bool
+    let message: String
+}
+
+/// Auto-export pipeline service. Pure logic for formatting; URLSession for webhook.
+nonisolated enum AutoExportService {
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "notetaker",
+        category: "AutoExportService"
+    )
+
+    // MARK: - Pipeline Execution
+
+    static func execute(
+        actions: [ExportAction],
+        sessionInfo: ExportSessionInfo,
+        urlSession: URLSession = .shared
+    ) async -> [ExportResult] {
+        var results: [ExportResult] = []
+        for action in actions {
+            let result = await executeAction(action, sessionInfo: sessionInfo, urlSession: urlSession)
+            results.append(result)
+            logger.info("Auto-export [\(action.id)]: \(result.success ? "success" : "failed") - \(result.message)")
+        }
+        return results
+    }
+
+    private static func executeAction(
+        _ action: ExportAction,
+        sessionInfo: ExportSessionInfo,
+        urlSession: URLSession
+    ) async -> ExportResult {
+        switch action {
+        case .writeFile(let options):
+            return writeFile(sessionInfo: sessionInfo, options: options)
+        case .copyTranscript:
+            return await copyTranscript(sessionInfo: sessionInfo)
+        case .webhook(let options):
+            return await sendWebhook(sessionInfo: sessionInfo, options: options, urlSession: urlSession)
+        }
+    }
+
+    // MARK: - Format Helpers
+
+    /// Format session as plain text for file export.
+    static func formatAsText(sessionInfo: ExportSessionInfo) -> String {
+        var lines: [String] = []
+        lines.append("# \(sessionInfo.title)")
+        lines.append("Date: \(formatDate(sessionInfo.date))")
+        lines.append("Duration: \(formatDuration(sessionInfo.duration))")
+        lines.append("")
+
+        if let summary = sessionInfo.overallSummary, !summary.isEmpty {
+            lines.append("## Summary")
+            lines.append(summary)
+            lines.append("")
+        }
+
+        if !sessionInfo.segments.isEmpty {
+            lines.append("## Transcript")
+            for seg in sessionInfo.segments {
+                let ts = formatTimestamp(seg.startTime)
+                lines.append("\(ts)  \(seg.text)")
+            }
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    /// Format timestamp as MM:SS.
+    static func formatTimestamp(_ time: TimeInterval) -> String {
+        let mins = Int(time) / 60
+        let secs = Int(time) % 60
+        return String(format: "%02d:%02d", mins, secs)
+    }
+
+    /// Format date as yyyy-MM-dd.
+    static func formatDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
+
+    /// Format duration as "Xm Ys".
+    static func formatDuration(_ duration: TimeInterval) -> String {
+        let mins = Int(duration) / 60
+        let secs = Int(duration) % 60
+        if mins > 0 {
+            return "\(mins)m \(secs)s"
+        }
+        return "\(secs)s"
+    }
+
+    /// Interpolate filename template with session metadata.
+    static func interpolateFilename(template: String, title: String, date: Date) -> String {
+        var result = template
+        let safeTitle = title
+            .replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ":", with: "-")
+            .replacingOccurrences(of: "\\", with: "-")
+        result = result.replacingOccurrences(of: "{{title}}", with: safeTitle)
+        result = result.replacingOccurrences(of: "{{date}}", with: formatDate(date))
+        return result
+    }
+
+    // MARK: - Actions
+
+    private static func writeFile(sessionInfo: ExportSessionInfo, options: WriteFileOptions) -> ExportResult {
+        guard !options.directoryPath.isEmpty else {
+            return ExportResult(actionID: "writeFile", success: false, message: "No directory configured")
+        }
+
+        let filename = interpolateFilename(
+            template: options.filenameTemplate,
+            title: sessionInfo.title,
+            date: sessionInfo.date
+        )
+        let url = URL(fileURLWithPath: options.directoryPath).appendingPathComponent("\(filename).md")
+        let content = formatAsText(sessionInfo: sessionInfo)
+
+        do {
+            try content.write(to: url, atomically: true, encoding: .utf8)
+            return ExportResult(actionID: "writeFile", success: true, message: url.lastPathComponent)
+        } catch {
+            return ExportResult(actionID: "writeFile", success: false, message: error.localizedDescription)
+        }
+    }
+
+    @MainActor
+    private static func copyTranscript(sessionInfo: ExportSessionInfo) -> ExportResult {
+        let text = formatAsText(sessionInfo: sessionInfo)
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(text, forType: .string)
+        return ExportResult(actionID: "copyTranscript", success: true, message: "\(text.count) chars copied")
+    }
+
+    private static func sendWebhook(
+        sessionInfo: ExportSessionInfo,
+        options: WebhookOptions,
+        urlSession: URLSession
+    ) async -> ExportResult {
+        guard let url = URL(string: options.url), !options.url.isEmpty else {
+            return ExportResult(actionID: "webhook", success: false, message: "Invalid webhook URL")
+        }
+
+        var payload: [String: Any] = [
+            "title": sessionInfo.title,
+            "date": ISO8601DateFormatter().string(from: sessionInfo.date),
+            "duration": sessionInfo.duration,
+        ]
+
+        if options.includeTranscript {
+            payload["transcript"] = sessionInfo.segments.map { [
+                "text": $0.text,
+                "startTime": $0.startTime,
+            ] as [String: Any] }
+        }
+
+        if options.includeSummary, let summary = sessionInfo.overallSummary {
+            payload["summary"] = summary
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = options.method
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if !options.secretHeader.isEmpty {
+            request.setValue(options.secretHeader, forHTTPHeaderField: "Authorization")
+        }
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+            let (_, response) = try await urlSession.data(for: request)
+            if let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) {
+                return ExportResult(actionID: "webhook", success: true, message: "HTTP \(http.statusCode)")
+            } else if let http = response as? HTTPURLResponse {
+                return ExportResult(actionID: "webhook", success: false, message: "HTTP \(http.statusCode)")
+            }
+            return ExportResult(actionID: "webhook", success: true, message: "Sent")
+        } catch {
+            return ExportResult(actionID: "webhook", success: false, message: error.localizedDescription)
+        }
+    }
+}

--- a/notetaker/Services/BackgroundSummaryService.swift
+++ b/notetaker/Services/BackgroundSummaryService.swift
@@ -159,6 +159,9 @@ final class BackgroundSummaryService {
                     context: context,
                     summarizerConfig: summarizerConfig
                 )
+
+                // Trigger auto-export after summary + title complete
+                await Self.triggerAutoExport(sessionID: sessionID, context: context)
             } catch is CancellationError {
                 Self.logger.info("Background summary cancelled for \(sessionID)")
             } catch {
@@ -171,10 +174,46 @@ final class BackgroundSummaryService {
                     context: context,
                     summarizerConfig: summarizerConfig
                 )
+
+                // Trigger auto-export even if summary failed (transcript still available)
+                await Self.triggerAutoExport(sessionID: sessionID, context: context)
             }
         }
 
         activeTasks[sessionID] = task
+    }
+
+    /// Trigger auto-export pipeline if enabled.
+    private static func triggerAutoExport(sessionID: UUID, context: ModelContext) async {
+        let exportConfig = AutoExportConfig.fromUserDefaults()
+        guard exportConfig.isEnabled, !exportConfig.actions.isEmpty else { return }
+
+        let predicate = #Predicate<RecordingSession> { $0.id == sessionID }
+        guard let session = try? context.fetch(FetchDescriptor(predicate: predicate)).first else {
+            logger.error("Session \(sessionID) not found for auto-export")
+            return
+        }
+
+        let segments = session.segments
+            .sorted { $0.startTime < $1.startTime }
+            .map { (startTime: $0.startTime, text: $0.text) }
+        let overallSummary = session.summaries
+            .first { $0.isOverall }?
+            .displayContent
+
+        let info = ExportSessionInfo(
+            title: session.title,
+            date: session.startedAt,
+            duration: session.totalDuration,
+            segments: segments,
+            overallSummary: overallSummary
+        )
+
+        logger.info("Triggering auto-export for session \(sessionID) with \(exportConfig.actions.count) action(s)")
+        let results = await AutoExportService.execute(actions: exportConfig.actions, sessionInfo: info)
+        let succeeded = results.filter(\.success).count
+        let failed = results.count - succeeded
+        logger.info("Auto-export complete for \(sessionID): \(succeeded) succeeded, \(failed) failed")
     }
 
     /// Generate a descriptive title for the session using the title LLM config.

--- a/notetaker/Views/AutoExportSettingsTab.swift
+++ b/notetaker/Views/AutoExportSettingsTab.swift
@@ -1,0 +1,267 @@
+import SwiftUI
+import os
+
+/// Settings tab for configuring the auto-export pipeline.
+struct AutoExportSettingsTab: View {
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "notetaker",
+        category: "AutoExportSettingsTab"
+    )
+
+    @State private var config = AutoExportConfig.fromUserDefaults()
+
+    var body: some View {
+        SettingsGrid {
+            SettingsRow("Auto-Export") {
+                Toggle("", isOn: $config.isEnabled)
+                    .labelsHidden()
+                    .help("Automatically export after recording + summary complete")
+            }
+
+            if config.isEnabled {
+                SettingsRow("Actions") {
+                    VStack(alignment: .leading, spacing: DS.Spacing.sm) {
+                        ForEach(config.actions.indices, id: \.self) { index in
+                            actionRow(at: index)
+                        }
+
+                        addActionMenu
+                    }
+                }
+
+                if config.actions.isEmpty {
+                    SettingsRow("") {
+                        SettingsDescription("Add actions to run after each recording completes.")
+                    }
+                }
+            }
+        }
+        .onChange(of: config) { _, newValue in
+            newValue.saveToUserDefaults()
+            Self.logger.debug("Auto-export config saved: enabled=\(newValue.isEnabled), actions=\(newValue.actions.count)")
+        }
+    }
+
+    // MARK: - Action Row
+
+    @ViewBuilder
+    private func actionRow(at index: Int) -> some View {
+        VStack(alignment: .leading, spacing: DS.Spacing.xs) {
+            HStack {
+                Image(systemName: config.actions[index].icon)
+                    .foregroundStyle(.secondary)
+                Text(config.actions[index].displayName)
+                    .font(DS.Typography.callout)
+                Spacer()
+                Button(role: .destructive) {
+                    config.actions.remove(at: index)
+                } label: {
+                    Image(systemName: "trash")
+                        .foregroundStyle(.red)
+                }
+                .buttonStyle(.plain)
+                .help("Remove action")
+            }
+
+            actionConfig(at: index)
+        }
+        .padding(DS.Spacing.sm)
+        .background(DS.Colors.cardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: DS.Radius.sm))
+    }
+
+    @ViewBuilder
+    private func actionConfig(at index: Int) -> some View {
+        switch config.actions[index] {
+        case .writeFile(let options):
+            writeFileConfig(options: options, index: index)
+        case .copyTranscript:
+            SettingsDescription("Copies formatted transcript + summary to clipboard.")
+        case .webhook(let options):
+            webhookConfig(options: options, index: index)
+        }
+    }
+
+    // MARK: - Write File Config
+
+    @ViewBuilder
+    private func writeFileConfig(options: WriteFileOptions, index: Int) -> some View {
+        VStack(alignment: .leading, spacing: DS.Spacing.xs) {
+            HStack {
+                Text("Directory:")
+                    .font(DS.Typography.caption)
+                Text(options.directoryPath.isEmpty ? "Not set" : options.directoryPath)
+                    .font(DS.Typography.caption)
+                    .foregroundStyle(options.directoryPath.isEmpty ? .red : .secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer()
+                Button("Choose...") {
+                    chooseDirectory(for: index)
+                }
+                .controlSize(.small)
+            }
+
+            HStack {
+                Text("Template:")
+                    .font(DS.Typography.caption)
+                TextField(
+                    "Filename template",
+                    text: Binding(
+                        get: { options.filenameTemplate },
+                        set: { config.actions[index] = .writeFile(WriteFileOptions(
+                            directoryPath: options.directoryPath,
+                            filenameTemplate: $0,
+                            includeTranscript: options.includeTranscript,
+                            includeSummary: options.includeSummary
+                        )) }
+                    )
+                )
+                .textFieldStyle(.roundedBorder)
+                .font(DS.Typography.caption)
+            }
+            SettingsDescription("Available: {{title}}, {{date}}")
+        }
+    }
+
+    // MARK: - Webhook Config
+
+    @ViewBuilder
+    private func webhookConfig(options: WebhookOptions, index: Int) -> some View {
+        VStack(alignment: .leading, spacing: DS.Spacing.xs) {
+            HStack {
+                Text("URL:")
+                    .font(DS.Typography.caption)
+                TextField(
+                    "https://example.com/webhook",
+                    text: Binding(
+                        get: { options.url },
+                        set: { config.actions[index] = .webhook(WebhookOptions(
+                            url: $0,
+                            method: options.method,
+                            includeTranscript: options.includeTranscript,
+                            includeSummary: options.includeSummary,
+                            secretHeader: options.secretHeader
+                        )) }
+                    )
+                )
+                .textFieldStyle(.roundedBorder)
+                .font(DS.Typography.caption)
+            }
+
+            HStack {
+                Text("Method:")
+                    .font(DS.Typography.caption)
+                Picker(
+                    "",
+                    selection: Binding(
+                        get: { options.method },
+                        set: { config.actions[index] = .webhook(WebhookOptions(
+                            url: options.url,
+                            method: $0,
+                            includeTranscript: options.includeTranscript,
+                            includeSummary: options.includeSummary,
+                            secretHeader: options.secretHeader
+                        )) }
+                    )
+                ) {
+                    Text("POST").tag("POST")
+                    Text("PUT").tag("PUT")
+                }
+                .labelsHidden()
+                .fixedSize()
+            }
+
+            HStack {
+                Text("Auth:")
+                    .font(DS.Typography.caption)
+                SecureField(
+                    "Authorization header (optional)",
+                    text: Binding(
+                        get: { options.secretHeader },
+                        set: { config.actions[index] = .webhook(WebhookOptions(
+                            url: options.url,
+                            method: options.method,
+                            includeTranscript: options.includeTranscript,
+                            includeSummary: options.includeSummary,
+                            secretHeader: $0
+                        )) }
+                    )
+                )
+                .textFieldStyle(.roundedBorder)
+                .font(DS.Typography.caption)
+            }
+
+            HStack(spacing: DS.Spacing.lg) {
+                Toggle("Transcript", isOn: Binding(
+                    get: { options.includeTranscript },
+                    set: { config.actions[index] = .webhook(WebhookOptions(
+                        url: options.url,
+                        method: options.method,
+                        includeTranscript: $0,
+                        includeSummary: options.includeSummary,
+                        secretHeader: options.secretHeader
+                    )) }
+                ))
+                .font(DS.Typography.caption)
+
+                Toggle("Summary", isOn: Binding(
+                    get: { options.includeSummary },
+                    set: { config.actions[index] = .webhook(WebhookOptions(
+                        url: options.url,
+                        method: options.method,
+                        includeTranscript: options.includeTranscript,
+                        includeSummary: $0,
+                        secretHeader: options.secretHeader
+                    )) }
+                ))
+                .font(DS.Typography.caption)
+            }
+        }
+    }
+
+    // MARK: - Add Action Menu
+
+    private var addActionMenu: some View {
+        Menu {
+            Button {
+                config.actions.append(.writeFile(WriteFileOptions()))
+            } label: {
+                Label("Write to File", systemImage: "doc.text")
+            }
+            Button {
+                config.actions.append(.copyTranscript)
+            } label: {
+                Label("Copy Transcript", systemImage: "doc.on.clipboard")
+            }
+            Button {
+                config.actions.append(.webhook(WebhookOptions()))
+            } label: {
+                Label("Send Webhook", systemImage: "arrow.up.forward.app")
+            }
+        } label: {
+            Label("Add Action", systemImage: "plus.circle")
+                .font(DS.Typography.callout)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+    }
+
+    // MARK: - Directory Picker
+
+    private func chooseDirectory(for index: Int) {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.message = "Choose export directory"
+        panel.prompt = "Select"
+
+        if panel.runModal() == .OK, let url = panel.url {
+            if case .writeFile(var options) = config.actions[index] {
+                options.directoryPath = url.path
+                config.actions[index] = .writeFile(options)
+            }
+        }
+    }
+}

--- a/notetaker/Views/SettingsView.swift
+++ b/notetaker/Views/SettingsView.swift
@@ -18,6 +18,9 @@ struct SettingsView: View {
             RecordingSettingsTab()
                 .tabItem { Label("Recording", systemImage: "mic") }
 
+            AutoExportSettingsTab()
+                .tabItem { Label("Export", systemImage: "square.and.arrow.up") }
+
             AboutTab()
                 .tabItem { Label("About", systemImage: "info.circle") }
         }

--- a/notetakerTests/AutoExportTests.swift
+++ b/notetakerTests/AutoExportTests.swift
@@ -1,0 +1,335 @@
+import Testing
+import Foundation
+@testable import notetaker
+
+@Suite(.serialized) struct AutoExportTests {
+
+    // MARK: - Helpers
+
+    private func makeSessionInfo(
+        title: String = "Test Session",
+        date: Date = Date(timeIntervalSince1970: 1_700_000_000),
+        duration: TimeInterval = 125,
+        segments: [(TimeInterval, String)] = [(0, "Hello"), (65, "World")],
+        overallSummary: String? = "A test summary."
+    ) -> ExportSessionInfo {
+        ExportSessionInfo(
+            title: title,
+            date: date,
+            duration: duration,
+            segments: segments.map { (startTime: $0.0, text: $0.1) },
+            overallSummary: overallSummary
+        )
+    }
+
+    // MARK: - formatTimestamp
+
+    @Test func formatTimestamp_zeroSeconds() {
+        #expect(AutoExportService.formatTimestamp(0) == "00:00")
+    }
+
+    @Test func formatTimestamp_65seconds() {
+        #expect(AutoExportService.formatTimestamp(65) == "01:05")
+    }
+
+    @Test func formatTimestamp_3661seconds() {
+        #expect(AutoExportService.formatTimestamp(3661) == "61:01")
+    }
+
+    // MARK: - formatDate
+
+    @Test func formatDate_knownDate() {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let result = AutoExportService.formatDate(date)
+        // 2023-11-14 in UTC (exact date depends on timezone, just check format)
+        #expect(result.count == 10)
+        #expect(result.contains("-"))
+    }
+
+    // MARK: - formatDuration
+
+    @Test func formatDuration_secondsOnly() {
+        #expect(AutoExportService.formatDuration(45) == "45s")
+    }
+
+    @Test func formatDuration_minutesAndSeconds() {
+        #expect(AutoExportService.formatDuration(125) == "2m 5s")
+    }
+
+    @Test func formatDuration_zeroSeconds() {
+        #expect(AutoExportService.formatDuration(0) == "0s")
+    }
+
+    // MARK: - interpolateFilename
+
+    @Test func interpolateFilename_titleAndDate() {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let result = AutoExportService.interpolateFilename(
+            template: "{{title}}_{{date}}",
+            title: "My Session",
+            date: date
+        )
+        #expect(result.contains("My Session"))
+        #expect(result.contains("_"))
+        // Date portion should be yyyy-MM-dd format
+        let parts = result.split(separator: "_")
+        #expect(parts.count == 2)
+    }
+
+    @Test func interpolateFilename_sanitizesSpecialChars() {
+        let date = Date(timeIntervalSince1970: 0)
+        let result = AutoExportService.interpolateFilename(
+            template: "{{title}}",
+            title: "My/Session:With\\Slashes",
+            date: date
+        )
+        #expect(!result.contains("/"))
+        #expect(!result.contains(":"))
+        #expect(!result.contains("\\"))
+        #expect(result.contains("My-Session-With-Slashes"))
+    }
+
+    @Test func interpolateFilename_noPlaceholders() {
+        let date = Date(timeIntervalSince1970: 0)
+        let result = AutoExportService.interpolateFilename(template: "fixed-name", title: "ignored", date: date)
+        #expect(result == "fixed-name")
+    }
+
+    // MARK: - formatAsText
+
+    @Test func formatAsText_withSummaryAndSegments() {
+        let info = makeSessionInfo()
+        let text = AutoExportService.formatAsText(sessionInfo: info)
+
+        #expect(text.contains("# Test Session"))
+        #expect(text.contains("## Summary"))
+        #expect(text.contains("A test summary."))
+        #expect(text.contains("## Transcript"))
+        #expect(text.contains("00:00  Hello"))
+        #expect(text.contains("01:05  World"))
+        #expect(text.contains("Duration: 2m 5s"))
+    }
+
+    @Test func formatAsText_withoutSummary() {
+        let info = makeSessionInfo(overallSummary: nil)
+        let text = AutoExportService.formatAsText(sessionInfo: info)
+
+        #expect(text.contains("# Test Session"))
+        #expect(!text.contains("## Summary"))
+        #expect(text.contains("## Transcript"))
+    }
+
+    @Test func formatAsText_emptySegments() {
+        let info = makeSessionInfo(segments: [], overallSummary: nil)
+        let text = AutoExportService.formatAsText(sessionInfo: info)
+
+        #expect(text.contains("# Test Session"))
+        #expect(!text.contains("## Transcript"))
+    }
+
+    // MARK: - AutoExportConfig round-trip
+
+    @Test func configJsonRoundTrip() throws {
+        let config = AutoExportConfig(
+            isEnabled: true,
+            actions: [
+                .writeFile(WriteFileOptions(directoryPath: "/tmp", filenameTemplate: "{{title}}")),
+                .copyTranscript,
+                .webhook(WebhookOptions(url: "https://example.com", method: "POST")),
+            ]
+        )
+
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(AutoExportConfig.self, from: data)
+
+        #expect(decoded == config)
+        #expect(decoded.isEnabled == true)
+        #expect(decoded.actions.count == 3)
+    }
+
+    @Test func configDefaultValues() {
+        let config = AutoExportConfig()
+        #expect(config.isEnabled == false)
+        #expect(config.actions.isEmpty)
+    }
+
+    // MARK: - ExportAction properties
+
+    @Test func exportActionDisplayName() {
+        #expect(ExportAction.writeFile(WriteFileOptions()).displayName == "Write to File")
+        #expect(ExportAction.copyTranscript.displayName == "Copy Transcript")
+        #expect(ExportAction.webhook(WebhookOptions()).displayName == "Send Webhook")
+    }
+
+    @Test func exportActionIcon() {
+        #expect(ExportAction.writeFile(WriteFileOptions()).icon == "doc.text")
+        #expect(ExportAction.copyTranscript.icon == "doc.on.clipboard")
+        #expect(ExportAction.webhook(WebhookOptions()).icon == "arrow.up.forward.app")
+    }
+
+    @Test func exportActionID() {
+        #expect(ExportAction.writeFile(WriteFileOptions()).id == "writeFile")
+        #expect(ExportAction.copyTranscript.id == "copyTranscript")
+        #expect(ExportAction.webhook(WebhookOptions()).id == "webhook")
+    }
+
+    // MARK: - Pipeline execution
+
+    @Test func executeWithEmptyActions() async {
+        let info = makeSessionInfo()
+        let results = await AutoExportService.execute(actions: [], sessionInfo: info)
+        #expect(results.isEmpty)
+    }
+
+    @Test func writeFileWithEmptyDirectory() async {
+        let info = makeSessionInfo()
+        let results = await AutoExportService.execute(
+            actions: [.writeFile(WriteFileOptions(directoryPath: ""))],
+            sessionInfo: info
+        )
+        #expect(results.count == 1)
+        #expect(results[0].success == false)
+        #expect(results[0].message == "No directory configured")
+    }
+
+    @Test func writeFileToTempDirectory() async throws {
+        let tmpDir = NSTemporaryDirectory()
+            .appending("autoexport_test_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(atPath: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: tmpDir) }
+
+        let info = makeSessionInfo(title: "Export Test")
+        let options = WriteFileOptions(
+            directoryPath: tmpDir,
+            filenameTemplate: "{{title}}_{{date}}"
+        )
+        let results = await AutoExportService.execute(
+            actions: [.writeFile(options)],
+            sessionInfo: info
+        )
+
+        #expect(results.count == 1)
+        #expect(results[0].success == true)
+
+        // Verify file was written
+        let files = try FileManager.default.contentsOfDirectory(atPath: tmpDir)
+        #expect(files.count == 1)
+        #expect(files[0].hasSuffix(".md"))
+        #expect(files[0].contains("Export Test"))
+    }
+
+    @Test func webhookWithInvalidURL() async {
+        let info = makeSessionInfo()
+        let options = WebhookOptions(url: "")
+        let results = await AutoExportService.execute(
+            actions: [.webhook(options)],
+            sessionInfo: info
+        )
+        #expect(results.count == 1)
+        #expect(results[0].success == false)
+        #expect(results[0].message == "Invalid webhook URL")
+    }
+
+    @Test func webhookWithMockURLSession() async {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [AutoExportMockURLProtocol.self]
+        let session = URLSession(configuration: config)
+
+        AutoExportMockURLProtocol.handler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (Data(), response)
+        }
+
+        let info = makeSessionInfo()
+        let options = WebhookOptions(
+            url: "https://example.com/webhook",
+            method: "POST",
+            includeTranscript: true,
+            includeSummary: true
+        )
+        let results = await AutoExportService.execute(
+            actions: [.webhook(options)],
+            sessionInfo: info,
+            urlSession: session
+        )
+
+        #expect(results.count == 1)
+        #expect(results[0].success == true)
+        #expect(results[0].message == "HTTP 200")
+    }
+
+    @Test func webhookWithErrorResponse() async {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [AutoExportMockURLProtocol.self]
+        let session = URLSession(configuration: config)
+
+        AutoExportMockURLProtocol.handler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 500,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (Data(), response)
+        }
+
+        let info = makeSessionInfo()
+        let options = WebhookOptions(url: "https://example.com/webhook")
+        let results = await AutoExportService.execute(
+            actions: [.webhook(options)],
+            sessionInfo: info,
+            urlSession: session
+        )
+
+        #expect(results.count == 1)
+        #expect(results[0].success == false)
+        #expect(results[0].message == "HTTP 500")
+    }
+
+    @Test func multipleActionsExecuteIndependently() async {
+        let info = makeSessionInfo()
+        let results = await AutoExportService.execute(
+            actions: [
+                .writeFile(WriteFileOptions(directoryPath: "")),
+                .webhook(WebhookOptions(url: "")),
+            ],
+            sessionInfo: info
+        )
+
+        // Both should fail independently
+        #expect(results.count == 2)
+        #expect(results[0].success == false)
+        #expect(results[1].success == false)
+    }
+}
+
+// MARK: - Mock URLProtocol (per-suite to avoid shared state)
+
+private final class AutoExportMockURLProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (Data, HTTPURLResponse))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+        do {
+            let (data, response) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}


### PR DESCRIPTION
## Summary
- `AutoExportConfig` model with 3 action types: write file, copy transcript, webhook
- `AutoExportService` (nonisolated enum) — format + execute pipeline with injectable URLSession
- `AutoExportSettingsTab` in Settings > Export tab for enabling/configuring auto-export actions
- `BackgroundSummaryService` integration — triggers after summary+title complete (both success and error paths)
- 25 unit tests for formatting, config serialization, and pipeline execution

Closes #39

## Test plan
- [x] Build succeeds
- [x] AutoExportTests (25 tests) pass
- [ ] Manual: enable auto-export, configure write-to-file, record → verify file created
- [ ] Manual: configure webhook, record → verify POST sent
- [ ] Manual: verify copy-transcript puts formatted text on clipboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)