### PR TITLE
feat: token counting and cost estimation for LLM usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ xcodebuild -scheme notetaker -configuration Debug -only-testing:notetakerUITests
 - **Multi-clip recording**: Pause/resume creates separate audio clips stored in `RecordingSession.audioFilePaths: [String]`; `AudioExporter.mergeAndExport()` combines them on session completion; `audioFilePath` (singular) retained for backward compatibility
 - **`SummaryMarkdownFormatter`**: Formats `SummaryBlock` content as Markdown with time-range or "Overall Summary" heading; used by copy-summary feature
 - **`AudioConfig`**: `nonisolated Sendable` struct with `sampleRate`, `channels`, `bufferDurationSeconds`; `AudioConfig.default` = 16kHz mono, 30s buffer
+- **Token Counting & Cost Estimation**: `TokenPricing` (nonisolated enum) provides pricing lookup for OpenAI/Anthropic/Gemini models, free for Foundation Models and Ollama; `TokenUsageTracker` (nonisolated enum) accumulates daily usage in UserDefaults with date-range queries (today/week/month); `SummarizerService.retryableGenerate()` and `ChatService.sendMessage()` record usage after each LLM call; `UsageStatsView` in Settings "Usage" tab shows cumulative stats with reset; no schema migration — cumulative data only in UserDefaults
 
 ### Thread Safety
 - `SpeechAnalyzerEngine` uses serial `DispatchQueue` for thread safety — all mutable state accessed through `queue`; `stopRecognition()` is async with 4-phase drain (finish input → finalize analyzer → await resultTask with 2s timeout → cleanup with sessionID guard); `stopRecognitionLocked()` is the synchronous force-stop used internally by `startRecognition()`
@@ -138,11 +139,11 @@ Three-layer architecture: Views → ViewModels → Services, with SwiftData `@Mo
 - **`notetaker/`** — Main app target
   - `notetakerApp.swift` — Entry point, shared `ModelContainer`, `MenuBarExtra`, `Settings` scene
   - `ContentView.swift` — `NavigationSplitView` (sidebar session list + detail routing)
-  - `Models/` — SwiftData models (`RecordingSession`, `TranscriptSegment`, `SummaryBlock`, `ScheduledRecording`), config types (`LLMConfig`, `SummarizerConfig`, `LLMModelProfile`, `VADConfig`, `OverallSummaryMode`, `RepeatRule`), ephemeral types (`ChatMessage`), schema versioning (`Schemas/` V1–V6)
-  - `Services/` — Protocol-based engines (`ASREngine`, `LLMEngine`) with multiple implementations (including `FoundationModelsEngine` for Apple Intelligence), `AudioCaptureService`, `AudioPlaybackService`, `AudioExporter`, `SummarizerService`, `BackgroundSummaryService`, `SummaryMarkdownFormatter`, `ChatService`, `PromptBuilder`, `KeychainService`, `CrashLogService`, `SchedulerService`, `CalendarService`
+  - `Models/` — SwiftData models (`RecordingSession`, `TranscriptSegment`, `SummaryBlock`, `ScheduledRecording`), config types (`LLMConfig`, `SummarizerConfig`, `LLMModelProfile`, `VADConfig`, `OverallSummaryMode`, `RepeatRule`, `TokenPricing`), ephemeral types (`ChatMessage`), schema versioning (`Schemas/` V1–V6)
+  - `Services/` — Protocol-based engines (`ASREngine`, `LLMEngine`) with multiple implementations (including `FoundationModelsEngine` for Apple Intelligence), `AudioCaptureService`, `AudioPlaybackService`, `AudioExporter`, `SummarizerService`, `BackgroundSummaryService`, `SummaryMarkdownFormatter`, `ChatService`, `PromptBuilder`, `KeychainService`, `CrashLogService`, `SchedulerService`, `CalendarService`, `TokenUsageTracker`
   - `ViewModels/` — `RecordingViewModel` (`@Observable`) — central state machine for recording lifecycle; `SchedulerViewModel` — scheduled recordings + calendar integration
   - `DesignSystem.swift` — `DS` enum (spacing, typography, colors, radius, layout tokens)
-  - `Views/` — SwiftUI views including `SettingsView` (4-tab layout: `SettingsTab`, `ModelsSettingsTab`, `AboutTab`), `ScheduleView`, `ScheduleEditorView`, `PrivacyDisclosureView`, `SummaryCardView`, `TranscriptSegmentRow`, `AudioLevelBar`, `ResizeHandle`, `VerticalResizeHandle`, `ChatView`, `SettingsComponents` (reusable settings UI), `ViewModifiers`
+  - `Views/` — SwiftUI views including `SettingsView` (6-tab layout: `ModelsSettingsTab`, `LLMAssignmentTab`, `SummarizationSettingsTab`, `RecordingSettingsTab`, `UsageStatsView`, `AboutTab`), `ScheduleView`, `ScheduleEditorView`, `PrivacyDisclosureView`, `SummaryCardView`, `TranscriptSegmentRow`, `AudioLevelBar`, `ResizeHandle`, `VerticalResizeHandle`, `ChatView`, `SettingsComponents` (reusable settings UI), `ViewModifiers`
 - **`notetakerTests/`** — Swift Testing (`@Test`, `#expect`); ~64 test files; `Mocks/` has `MockASREngine`, `MockLLMEngine`, `MockSchedulerService`, per-suite `MockURLProtocol` subclasses; `Helpers/` has `BufferFactory` and `FileAudioSource`
 - **`notetakerUITests/`** — XCTest UI tests (light/dark mode via `runsForEachTargetApplicationUIConfiguration`)
 - **`scripts/`** — `increment_build_number.sh`
@@ -162,9 +163,9 @@ Three-layer architecture: Views → ViewModels → Services, with SwiftData `@Mo
 - `DispatchQueue.main.asyncAfter` may not fire during `Task.sleep`-based polling in Swift Testing — use `DispatchQueue.global()` or avoid dispatch
 - UI launch tests use `runsForEachTargetApplicationUIConfiguration = true` to test light/dark mode; do NOT delete
 - **Close the app before running tests** — if the app is already running, UI tests attach to the existing instance instead of launching a fresh one, causing `Failed to terminate` errors and test failures
-- **Two-tier test plans**: `UnitTests.xctestplan` (22 pure-logic suites, ~257 tests, <0.2s) is default for Cmd+U; `FullTests.xctestplan` (all suites + UI tests) for CI on PR to main; shared scheme at `xcshareddata/xcschemes/notetaker.xcscheme` associates both plans
+- **Two-tier test plans**: `UnitTests.xctestplan` (23 pure-logic suites, ~279 tests, <0.2s) is default for Cmd+U; `FullTests.xctestplan` (all suites + UI tests) for CI on PR to main; shared scheme at `xcshareddata/xcschemes/notetaker.xcscheme` associates both plans
 - **Test plan gotcha**: Xcode auto-generated schemes don't support `-testPlan`; the explicit shared scheme with `shouldAutocreateTestPlan = "NO"` is required; verify with `xcodebuild -scheme notetaker -showTestPlans`
-- 31 test suites use `.serialized` to prevent parallel UserDefaults/Keychain/URLProtocol/SwiftData/NSPasteboard contamination; ~746 tests total across ~64 test files; UnitTests plan excludes all serialized suites for fast local iteration
+- 32 test suites use `.serialized` to prevent parallel UserDefaults/Keychain/URLProtocol/SwiftData/NSPasteboard contamination; ~768 tests total across ~65 test files; UnitTests plan excludes all serialized suites for fast local iteration
 
 ## CI Workflows
 

--- a/UnitTests.xctestplan
+++ b/UnitTests.xctestplan
@@ -48,6 +48,7 @@
         "ToolCallingErrorTests",
         "SyntheticBufferInjectionTests",
         "TimeIntervalFormattingTests",
+        "TokenCountingTests",
         "TranscriptSegmentTests",
         "VADConfigTests"
       ]

--- a/notetaker/Models/TokenPricing.swift
+++ b/notetaker/Models/TokenPricing.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Token pricing per million tokens for known LLM providers and models.
+nonisolated enum TokenPricing {
+    struct Rate: Sendable {
+        let inputPerMillion: Double   // USD per million input tokens
+        let outputPerMillion: Double  // USD per million output tokens
+    }
+
+    /// Lookup pricing for a provider + model combination.
+    static func rate(provider: LLMProvider, model: String) -> Rate? {
+        // Free providers
+        if provider == .foundationModels || provider == .ollama {
+            return Rate(inputPerMillion: 0, outputPerMillion: 0)
+        }
+
+        let modelLower = model.lowercased()
+
+        // OpenAI models
+        if modelLower.contains("gpt-4o-mini") { return Rate(inputPerMillion: 0.15, outputPerMillion: 0.60) }
+        if modelLower.contains("gpt-4o") { return Rate(inputPerMillion: 2.50, outputPerMillion: 10.0) }
+        if modelLower.contains("gpt-4") { return Rate(inputPerMillion: 30.0, outputPerMillion: 60.0) }
+        if modelLower.contains("o3-mini") { return Rate(inputPerMillion: 1.10, outputPerMillion: 4.40) }
+        if modelLower.contains("o3") { return Rate(inputPerMillion: 2.0, outputPerMillion: 8.0) }
+        if modelLower.contains("o4-mini") { return Rate(inputPerMillion: 1.10, outputPerMillion: 4.40) }
+
+        // Anthropic models
+        if modelLower.contains("claude-3-5-haiku") || modelLower.contains("claude-haiku") {
+            return Rate(inputPerMillion: 0.80, outputPerMillion: 4.0)
+        }
+        if modelLower.contains("claude-sonnet-4") || modelLower.contains("claude-3-5-sonnet") || modelLower.contains("claude-sonnet") {
+            return Rate(inputPerMillion: 3.0, outputPerMillion: 15.0)
+        }
+        if modelLower.contains("claude-opus") {
+            return Rate(inputPerMillion: 15.0, outputPerMillion: 75.0)
+        }
+
+        // Gemini models
+        if modelLower.contains("gemini") && modelLower.contains("flash") {
+            return Rate(inputPerMillion: 0.075, outputPerMillion: 0.30)
+        }
+        if modelLower.contains("gemini") && modelLower.contains("pro") {
+            return Rate(inputPerMillion: 1.25, outputPerMillion: 5.0)
+        }
+
+        // Custom/local — unknown pricing
+        return nil
+    }
+
+    /// Calculate cost for given token usage.
+    static func estimateCost(usage: TokenUsage, provider: LLMProvider, model: String) -> Double? {
+        guard let rate = rate(provider: provider, model: model) else { return nil }
+        let inputCost = Double(usage.inputTokens) / 1_000_000.0 * rate.inputPerMillion
+        let outputCost = Double(usage.outputTokens) / 1_000_000.0 * rate.outputPerMillion
+        return inputCost + outputCost
+    }
+
+    /// Format cost as string: "$0.003" or "Free" or nil for unknown.
+    static func formatCost(_ cost: Double?) -> String? {
+        guard let cost else { return nil }
+        if cost == 0 { return "Free" }
+        if cost < 0.01 { return "<$0.01" }
+        return String(format: "$%.2f", cost)
+    }
+
+    /// Format token count: "1,234 tokens"
+    static func formatTokens(_ count: Int) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return "\(formatter.string(from: NSNumber(value: count)) ?? "\(count)") tokens"
+    }
+}

--- a/notetaker/Services/ChatService.swift
+++ b/notetaker/Services/ChatService.swift
@@ -41,6 +41,10 @@ nonisolated final class ChatService: @unchecked Sendable {
 
         if let usage = response.usage {
             Self.logger.info("Chat tokens — input: \(usage.inputTokens), output: \(usage.outputTokens)")
+            TokenUsageTracker.record(
+                usage: usage,
+                estimatedCost: TokenPricing.estimateCost(usage: usage, provider: llmConfig.provider, model: llmConfig.model)
+            )
         }
 
         let assistantMessage = ChatMessage(role: .assistant, content: response.content.trimmingCharacters(in: .whitespacesAndNewlines))

--- a/notetaker/Services/SummarizerService.swift
+++ b/notetaker/Services/SummarizerService.swift
@@ -24,6 +24,12 @@ nonisolated final class SummarizerService: @unchecked Sendable {
                 if let usage = result.usage {
                     Self.logger.info("\(label) tokens: input=\(usage.inputTokens) output=\(usage.outputTokens) cache_create=\(usage.cacheCreationTokens) cache_read=\(usage.cacheReadTokens)")
                 }
+                if let usage = result.usage {
+                    TokenUsageTracker.record(
+                        usage: usage,
+                        estimatedCost: TokenPricing.estimateCost(usage: usage, provider: llmConfig.provider, model: llmConfig.model)
+                    )
+                }
                 return LLMMessage(role: .assistant, content: trimmedContent, usage: result.usage)
             } catch is CancellationError {
                 Self.logger.info("\(label) cancelled on attempt \(attempt + 1)")

--- a/notetaker/Services/TokenUsageTracker.swift
+++ b/notetaker/Services/TokenUsageTracker.swift
@@ -1,0 +1,100 @@
+import Foundation
+import os
+
+/// Tracks cumulative token usage across sessions, stored daily in UserDefaults.
+nonisolated enum TokenUsageTracker {
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "notetaker", category: "TokenUsageTracker")
+    static let storageKey = "tokenUsageDaily"
+
+    struct DailyUsage: Codable, Sendable, Equatable {
+        var promptTokens: Int = 0
+        var completionTokens: Int = 0
+        var requestCount: Int = 0
+        var estimatedCost: Double = 0
+
+        var totalTokens: Int { promptTokens + completionTokens }
+    }
+
+    /// Record a token usage event.
+    static func record(usage: TokenUsage, estimatedCost: Double?, date: Date = Date(), defaults: UserDefaults = .standard) {
+        var daily = loadDaily(defaults: defaults)
+        let key = dateKey(date)
+        var entry = daily[key] ?? DailyUsage()
+        entry.promptTokens += usage.inputTokens
+        entry.completionTokens += usage.outputTokens
+        entry.requestCount += 1
+        entry.estimatedCost += estimatedCost ?? 0
+        daily[key] = entry
+        saveDaily(daily, defaults: defaults)
+        logger.debug("Recorded \(usage.inputTokens + usage.outputTokens) tokens for \(key)")
+    }
+
+    /// Get usage for a date range.
+    static func usage(from startDate: Date, to endDate: Date, defaults: UserDefaults = .standard) -> DailyUsage {
+        let daily = loadDaily(defaults: defaults)
+        var total = DailyUsage()
+        var current = Calendar.current.startOfDay(for: startDate)
+        let end = Calendar.current.startOfDay(for: endDate)
+
+        while current <= end {
+            if let entry = daily[dateKey(current)] {
+                total.promptTokens += entry.promptTokens
+                total.completionTokens += entry.completionTokens
+                total.requestCount += entry.requestCount
+                total.estimatedCost += entry.estimatedCost
+            }
+            guard let next = Calendar.current.date(byAdding: .day, value: 1, to: current) else { break }
+            current = next
+        }
+        return total
+    }
+
+    /// Get total tokens for today.
+    static func todayUsage(defaults: UserDefaults = .standard) -> DailyUsage {
+        let today = Date()
+        return usage(from: today, to: today, defaults: defaults)
+    }
+
+    /// Get total tokens for last 7 days.
+    static func weekUsage(defaults: UserDefaults = .standard) -> DailyUsage {
+        let now = Date()
+        let weekAgo = Calendar.current.date(byAdding: .day, value: -6, to: now)!
+        return usage(from: weekAgo, to: now, defaults: defaults)
+    }
+
+    /// Get total tokens for last 30 days.
+    static func monthUsage(defaults: UserDefaults = .standard) -> DailyUsage {
+        let now = Date()
+        let monthAgo = Calendar.current.date(byAdding: .day, value: -29, to: now)!
+        return usage(from: monthAgo, to: now, defaults: defaults)
+    }
+
+    /// Reset all usage data.
+    static func resetAll(defaults: UserDefaults = .standard) {
+        defaults.removeObject(forKey: storageKey)
+        logger.info("Token usage data reset")
+    }
+
+    // MARK: - Internal (visible for testing)
+
+    static func dateKey(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter.string(from: date)
+    }
+
+    static func loadDaily(defaults: UserDefaults = .standard) -> [String: DailyUsage] {
+        guard let data = defaults.data(forKey: storageKey),
+              let daily = try? JSONDecoder().decode([String: DailyUsage].self, from: data) else {
+            return [:]
+        }
+        return daily
+    }
+
+    private static func saveDaily(_ daily: [String: DailyUsage], defaults: UserDefaults = .standard) {
+        if let data = try? JSONEncoder().encode(daily) {
+            defaults.set(data, forKey: storageKey)
+        }
+    }
+}

--- a/notetaker/Views/SettingsView.swift
+++ b/notetaker/Views/SettingsView.swift
@@ -18,6 +18,9 @@ struct SettingsView: View {
             RecordingSettingsTab()
                 .tabItem { Label("Recording", systemImage: "mic") }
 
+            UsageStatsView()
+                .tabItem { Label("Usage", systemImage: "chart.bar") }
+
             AboutTab()
                 .tabItem { Label("About", systemImage: "info.circle") }
         }

--- a/notetaker/Views/UsageStatsView.swift
+++ b/notetaker/Views/UsageStatsView.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+/// Settings tab showing cumulative token usage and cost statistics.
+struct UsageStatsView: View {
+    @State private var todayUsage = TokenUsageTracker.DailyUsage()
+    @State private var weekUsage = TokenUsageTracker.DailyUsage()
+    @State private var monthUsage = TokenUsageTracker.DailyUsage()
+    @State private var showResetConfirmation = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DS.Spacing.lg) {
+            Text("Token Usage")
+                .font(DS.Typography.title)
+
+            HStack(alignment: .top, spacing: DS.Spacing.lg) {
+                usageCard(title: "Today", usage: todayUsage)
+                usageCard(title: "This Week", usage: weekUsage)
+                usageCard(title: "This Month", usage: monthUsage)
+            }
+
+            Spacer()
+
+            HStack {
+                Spacer()
+                Button("Reset Usage Data") {
+                    showResetConfirmation = true
+                }
+                .alert("Reset Usage Data?", isPresented: $showResetConfirmation) {
+                    Button("Cancel", role: .cancel) {}
+                    Button("Reset", role: .destructive) {
+                        TokenUsageTracker.resetAll()
+                        refreshUsage()
+                    }
+                } message: {
+                    Text("This will permanently delete all accumulated token usage statistics.")
+                }
+            }
+        }
+        .padding(DS.Spacing.xl)
+        .onAppear { refreshUsage() }
+    }
+
+    private func usageCard(title: String, usage: TokenUsageTracker.DailyUsage) -> some View {
+        VStack(alignment: .leading, spacing: DS.Spacing.sm) {
+            Text(title)
+                .font(DS.Typography.sectionHeader)
+
+            Divider()
+
+            statRow(label: "Total Tokens", value: TokenPricing.formatTokens(usage.totalTokens))
+            statRow(label: "Input", value: TokenPricing.formatTokens(usage.promptTokens))
+            statRow(label: "Output", value: TokenPricing.formatTokens(usage.completionTokens))
+            statRow(label: "Requests", value: "\(usage.requestCount)")
+
+            Divider()
+
+            statRow(label: "Est. Cost", value: costDisplay(usage.estimatedCost))
+        }
+        .padding(DS.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(DS.Colors.cardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: DS.Radius.md))
+    }
+
+    private func statRow(label: String, value: String) -> some View {
+        HStack {
+            Text(label)
+                .font(DS.Typography.caption)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+                .font(DS.Typography.callout)
+        }
+    }
+
+    private func costDisplay(_ cost: Double) -> String {
+        if cost == 0 { return "Free" }
+        if cost < 0.01 { return "<$0.01" }
+        return String(format: "$%.2f", cost)
+    }
+
+    private func refreshUsage() {
+        todayUsage = TokenUsageTracker.todayUsage()
+        weekUsage = TokenUsageTracker.weekUsage()
+        monthUsage = TokenUsageTracker.monthUsage()
+    }
+}

--- a/notetakerTests/TokenCountingTests.swift
+++ b/notetakerTests/TokenCountingTests.swift
@@ -1,0 +1,230 @@
+import Testing
+import Foundation
+@testable import notetaker
+
+@Suite(.serialized)
+struct TokenCountingTests {
+
+    // Use isolated UserDefaults to prevent cross-test contamination
+    private let defaults = UserDefaults(suiteName: "TokenCountingTests")!
+
+    init() {
+        defaults.removePersistentDomain(forName: "TokenCountingTests")
+    }
+
+    // MARK: - TokenPricing.rate
+
+    @Test func freeProviders() {
+        let foundationRate = TokenPricing.rate(provider: .foundationModels, model: "any-model")
+        #expect(foundationRate != nil)
+        #expect(foundationRate!.inputPerMillion == 0)
+        #expect(foundationRate!.outputPerMillion == 0)
+
+        let ollamaRate = TokenPricing.rate(provider: .ollama, model: "llama3")
+        #expect(ollamaRate != nil)
+        #expect(ollamaRate!.inputPerMillion == 0)
+        #expect(ollamaRate!.outputPerMillion == 0)
+    }
+
+    @Test func openAIModelPricing() {
+        let gpt4oMini = TokenPricing.rate(provider: .openAI, model: "gpt-4o-mini-2024-07-18")
+        #expect(gpt4oMini != nil)
+        #expect(gpt4oMini!.inputPerMillion == 0.15)
+
+        let gpt4o = TokenPricing.rate(provider: .openAI, model: "gpt-4o")
+        #expect(gpt4o != nil)
+        #expect(gpt4o!.inputPerMillion == 2.50)
+
+        let o3mini = TokenPricing.rate(provider: .openAI, model: "o3-mini")
+        #expect(o3mini != nil)
+        #expect(o3mini!.inputPerMillion == 1.10)
+
+        let o4mini = TokenPricing.rate(provider: .openAI, model: "o4-mini-2025-04-16")
+        #expect(o4mini != nil)
+        #expect(o4mini!.inputPerMillion == 1.10)
+    }
+
+    @Test func anthropicModelPricing() {
+        let haiku = TokenPricing.rate(provider: .anthropic, model: "claude-3-5-haiku-20241022")
+        #expect(haiku != nil)
+        #expect(haiku!.inputPerMillion == 0.80)
+
+        let sonnet = TokenPricing.rate(provider: .anthropic, model: "claude-sonnet-4-20250514")
+        #expect(sonnet != nil)
+        #expect(sonnet!.inputPerMillion == 3.0)
+
+        let opus = TokenPricing.rate(provider: .anthropic, model: "claude-opus-4-20250514")
+        #expect(opus != nil)
+        #expect(opus!.inputPerMillion == 15.0)
+    }
+
+    @Test func geminiModelPricing() {
+        let flash = TokenPricing.rate(provider: .openAI, model: "gemini-2.0-flash")
+        #expect(flash != nil)
+        #expect(flash!.inputPerMillion == 0.075)
+
+        let pro = TokenPricing.rate(provider: .openAI, model: "gemini-1.5-pro")
+        #expect(pro != nil)
+        #expect(pro!.inputPerMillion == 1.25)
+    }
+
+    @Test func unknownModelReturnsNil() {
+        let rate = TokenPricing.rate(provider: .openAI, model: "some-unknown-model")
+        #expect(rate == nil)
+
+        let customRate = TokenPricing.rate(provider: .custom, model: "local-llama")
+        #expect(customRate == nil)
+    }
+
+    // MARK: - TokenPricing.estimateCost
+
+    @Test func estimateCostCalculation() {
+        let usage = TokenUsage(inputTokens: 1000, outputTokens: 500, cacheCreationTokens: 0, cacheReadTokens: 0)
+        let cost = TokenPricing.estimateCost(usage: usage, provider: .openAI, model: "gpt-4o")
+        #expect(cost != nil)
+        // input: 1000/1M * 2.50 = 0.0025, output: 500/1M * 10.0 = 0.005
+        let expected = 0.0025 + 0.005
+        #expect(abs(cost! - expected) < 0.0001)
+    }
+
+    @Test func estimateCostReturnsNilForUnknown() {
+        let usage = TokenUsage(inputTokens: 100, outputTokens: 50, cacheCreationTokens: 0, cacheReadTokens: 0)
+        let cost = TokenPricing.estimateCost(usage: usage, provider: .custom, model: "unknown")
+        #expect(cost == nil)
+    }
+
+    @Test func estimateCostFreeProvider() {
+        let usage = TokenUsage(inputTokens: 10000, outputTokens: 5000, cacheCreationTokens: 0, cacheReadTokens: 0)
+        let cost = TokenPricing.estimateCost(usage: usage, provider: .ollama, model: "llama3")
+        #expect(cost == 0)
+    }
+
+    // MARK: - TokenPricing.formatCost
+
+    @Test func formatCostFree() {
+        #expect(TokenPricing.formatCost(0) == "Free")
+    }
+
+    @Test func formatCostLessThanPenny() {
+        #expect(TokenPricing.formatCost(0.005) == "<$0.01")
+    }
+
+    @Test func formatCostNormal() {
+        #expect(TokenPricing.formatCost(1.23) == "$1.23")
+    }
+
+    @Test func formatCostNil() {
+        #expect(TokenPricing.formatCost(nil) == nil)
+    }
+
+    // MARK: - TokenPricing.formatTokens
+
+    @Test func formatTokensWithCommas() {
+        let result = TokenPricing.formatTokens(1234)
+        #expect(result == "1,234 tokens")
+    }
+
+    @Test func formatTokensZero() {
+        let result = TokenPricing.formatTokens(0)
+        #expect(result == "0 tokens")
+    }
+
+    @Test func formatTokensLarge() {
+        let result = TokenPricing.formatTokens(1_000_000)
+        #expect(result == "1,000,000 tokens")
+    }
+
+    // MARK: - TokenUsageTracker.dateKey
+
+    @Test func dateKeyFormat() {
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 3
+        components.day = 15
+        let date = Calendar.current.date(from: components)!
+        let key = TokenUsageTracker.dateKey(date)
+        #expect(key == "2026-03-15")
+    }
+
+    // MARK: - TokenUsageTracker.record + todayUsage
+
+    @Test func recordAccumulates() {
+        let usage1 = TokenUsage(inputTokens: 100, outputTokens: 50, cacheCreationTokens: 0, cacheReadTokens: 0)
+        let usage2 = TokenUsage(inputTokens: 200, outputTokens: 75, cacheCreationTokens: 0, cacheReadTokens: 0)
+
+        TokenUsageTracker.record(usage: usage1, estimatedCost: 0.01, defaults: defaults)
+        TokenUsageTracker.record(usage: usage2, estimatedCost: 0.02, defaults: defaults)
+
+        let today = TokenUsageTracker.todayUsage(defaults: defaults)
+        #expect(today.promptTokens == 300)
+        #expect(today.completionTokens == 125)
+        #expect(today.requestCount == 2)
+        #expect(abs(today.estimatedCost - 0.03) < 0.0001)
+    }
+
+    @Test func recordWithNilCost() {
+        let usage = TokenUsage(inputTokens: 500, outputTokens: 200, cacheCreationTokens: 0, cacheReadTokens: 0)
+        TokenUsageTracker.record(usage: usage, estimatedCost: nil, defaults: defaults)
+
+        let today = TokenUsageTracker.todayUsage(defaults: defaults)
+        #expect(today.promptTokens == 500)
+        #expect(today.estimatedCost == 0)
+    }
+
+    // MARK: - TokenUsageTracker.usage date range
+
+    @Test func usageDateRange() {
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        let usage1 = TokenUsage(inputTokens: 100, outputTokens: 50, cacheCreationTokens: 0, cacheReadTokens: 0)
+        let usage2 = TokenUsage(inputTokens: 200, outputTokens: 75, cacheCreationTokens: 0, cacheReadTokens: 0)
+
+        TokenUsageTracker.record(usage: usage1, estimatedCost: 0.01, date: yesterday, defaults: defaults)
+        TokenUsageTracker.record(usage: usage2, estimatedCost: 0.02, defaults: defaults) // today
+
+        let week = TokenUsageTracker.weekUsage(defaults: defaults)
+        #expect(week.promptTokens == 300)
+        #expect(week.completionTokens == 125)
+        #expect(week.requestCount == 2)
+
+        let today = TokenUsageTracker.todayUsage(defaults: defaults)
+        #expect(today.promptTokens == 200)
+        #expect(today.requestCount == 1)
+    }
+
+    // MARK: - TokenUsageTracker.resetAll
+
+    @Test func resetAllClearsData() {
+        let usage = TokenUsage(inputTokens: 100, outputTokens: 50, cacheCreationTokens: 0, cacheReadTokens: 0)
+        TokenUsageTracker.record(usage: usage, estimatedCost: 0.01, defaults: defaults)
+
+        let before = TokenUsageTracker.todayUsage(defaults: defaults)
+        #expect(before.requestCount == 1)
+
+        TokenUsageTracker.resetAll(defaults: defaults)
+
+        let after = TokenUsageTracker.todayUsage(defaults: defaults)
+        #expect(after.requestCount == 0)
+        #expect(after.totalTokens == 0)
+    }
+
+    // MARK: - DailyUsage Codable round-trip
+
+    @Test func dailyUsageCodableRoundTrip() throws {
+        let original = TokenUsageTracker.DailyUsage(
+            promptTokens: 1000,
+            completionTokens: 500,
+            requestCount: 5,
+            estimatedCost: 0.15
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(TokenUsageTracker.DailyUsage.self, from: data)
+        #expect(decoded == original)
+    }
+
+    // MARK: - DailyUsage totalTokens
+
+    @Test func dailyUsageTotalTokens() {
+        let usage = TokenUsageTracker.DailyUsage(promptTokens: 300, completionTokens: 200, requestCount: 1, estimatedCost: 0)
+        #expect(usage.totalTokens == 500)
+    }
+}


### PR DESCRIPTION
## Summary
- **`TokenPricing`** (nonisolated enum) — pricing lookup for OpenAI/Anthropic/Gemini models, free for Foundation Models and Ollama; cost calculation and formatting helpers
- **`TokenUsageTracker`** (nonisolated enum) — daily usage accumulation in UserDefaults with date-range queries (today/week/month); injectable `UserDefaults` for testing isolation
- **`UsageStatsView`** — new Settings "Usage" tab with today/week/month breakdown cards showing total tokens, input/output split, request count, and estimated cost; includes reset with confirmation
- **SummarizerService + ChatService integration** — records token usage after each `engine.generate()` call via `TokenUsageTracker.record()`
- **22 unit tests** covering pricing rates, cost estimation, formatting, daily accumulation, date ranges, reset, and Codable round-trip

Closes #87

## Test plan
- [x] Build succeeds (`CODE_SIGNING_ALLOWED=NO`)
- [x] All 22 TokenCountingTests pass
- [ ] Manual: generate summary -> check Settings Usage tab shows token count
- [ ] Manual: verify cost estimate matches provider pricing
- [ ] Manual: reset usage data clears all stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)