### PR TITLE
feat: Liquid Glass recording dashboard for macOS Tahoe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ xcodebuild -scheme notetaker -configuration Debug -only-testing:notetakerUITests
   - **V5**: Adds `isPartial: Bool = false` to RecordingSession for force-quit detection
   - **V6**: Adds `calendarEventIdentifier: String? = nil` to ScheduledRecording, `scheduledRecordingID: UUID? = nil` to RecordingSession
 - **Design System tokens**: `DS` enum in `DesignSystem.swift` centralizes spacing (4pt grid), typography, colors, radii, layout constants; `ViewModifiers.swift` provides `.cardStyle()` and `.badgeStyle()`; `ControlBarMetrics` aliases DS values
+- **Liquid Glass**: `DS.Glass` namespace provides `card(_:cornerRadius:)`, `capsule(_:)`, `tinted(_:color:cornerRadius:)` helpers — all gated by `#available(macOS 26, *)` with `ultraThinMaterial` fallback; `CardStyleModifier`/`BadgeStyleModifier` use `.glassEffect` on macOS 26; `SummaryCardGlassModifier` applies blue-tinted glass for overall summaries; `SessionHeaderGlassModifier` and `MenuBarRecordingGlassModifier` for detail header and menu bar indicators
 - **Session search**: `SessionListView` uses `.searchable()` filtering by title, segment text, summary content; debounced 300ms to prevent SwiftData fault storms; `DateFilter` enum for Today/This Week/This Month quick filters
 
 ### Privacy & App Store

--- a/UnitTests.xctestplan
+++ b/UnitTests.xctestplan
@@ -26,6 +26,7 @@
         "FileAudioSourceTests",
         "FoundationModelsEngineTests",
         "LLMConfigCoverageTests",
+        "LiquidGlassTests",
         "LLMHTTPHelpersTests",
         "LLMModelProfileCoverageTests",
         "LLMModelProfileTests",

--- a/notetaker/DesignSystem.swift
+++ b/notetaker/DesignSystem.swift
@@ -57,4 +57,43 @@ enum DS {
         static let controlBarMinHeight: CGFloat = 48
         static let timeMinWidth: CGFloat = 64
     }
+
+    // MARK: - Liquid Glass (macOS 26+)
+
+    /// Liquid Glass design tokens with automatic fallback to ultraThinMaterial on older macOS.
+    enum Glass {
+        /// Apply glass card effect with rounded rectangle shape.
+        @ViewBuilder
+        static func card<V: View>(_ content: V, cornerRadius: CGFloat = DS.Radius.md) -> some View {
+            if #available(macOS 26, *) {
+                content.glassEffect(.regular.tint(.clear), in: RoundedRectangle(cornerRadius: cornerRadius))
+            } else {
+                content
+                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: cornerRadius))
+            }
+        }
+
+        /// Apply glass capsule effect (for pills/badges).
+        @ViewBuilder
+        static func capsule<V: View>(_ content: V) -> some View {
+            if #available(macOS 26, *) {
+                content.glassEffect(.regular.tint(.clear), in: .capsule)
+            } else {
+                content
+                    .background(.ultraThinMaterial, in: Capsule())
+            }
+        }
+
+        /// Apply glass effect with semantic tint color.
+        @ViewBuilder
+        static func tinted<V: View>(_ content: V, color: Color, cornerRadius: CGFloat = DS.Radius.md) -> some View {
+            if #available(macOS 26, *) {
+                content.glassEffect(.regular.tint(color.opacity(0.3)), in: RoundedRectangle(cornerRadius: cornerRadius))
+            } else {
+                content
+                    .background(color.opacity(0.1), in: RoundedRectangle(cornerRadius: cornerRadius))
+                    .overlay(RoundedRectangle(cornerRadius: cornerRadius).strokeBorder(color.opacity(0.2), lineWidth: 0.5))
+            }
+        }
+    }
 }

--- a/notetaker/Views/AudioLevelBar.swift
+++ b/notetaker/Views/AudioLevelBar.swift
@@ -6,11 +6,17 @@ struct AudioLevelBar: View {
     var body: some View {
         GeometryReader { geometry in
             ZStack(alignment: .leading) {
-                RoundedRectangle(cornerRadius: DS.Radius.xs)
-                    .fill(.quaternary)
+                if #available(macOS 26, *) {
+                    RoundedRectangle(cornerRadius: DS.Radius.xs)
+                        .fill(.clear)
+                        .glassEffect(.regular.tint(.clear), in: RoundedRectangle(cornerRadius: DS.Radius.xs))
+                } else {
+                    RoundedRectangle(cornerRadius: DS.Radius.xs)
+                        .fill(.quaternary)
+                }
 
                 RoundedRectangle(cornerRadius: DS.Radius.xs)
-                    .fill(DS.Colors.audioLevel)
+                    .fill(DS.Colors.audioLevel.gradient)
                     .frame(width: geometry.size.width * CGFloat(max(0, min(1, level))))
             }
         }

--- a/notetaker/Views/SessionDetailView.swift
+++ b/notetaker/Views/SessionDetailView.swift
@@ -33,7 +33,7 @@ struct SessionDetailView: View {
         } else if let session {
             HStack(spacing: 0) {
             VStack(spacing: 0) {
-                // Header
+                // Header with glass card
                 VStack(alignment: .leading, spacing: DS.Spacing.xs) {
                     Text(session.title)
                         .font(DS.Typography.title)
@@ -43,6 +43,10 @@ struct SessionDetailView: View {
                         if session.totalDuration > 0 {
                             Text("·")
                             Text(session.totalDuration.compactDuration)
+                        }
+                        if !session.segments.isEmpty {
+                            Text("·")
+                            Text("\(session.segments.count) segments")
                         }
                         if session.isPartial {
                             Label("Incomplete — saved on quit", systemImage: "exclamationmark.triangle.fill")
@@ -54,6 +58,7 @@ struct SessionDetailView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding()
+                .modifier(SessionHeaderGlassModifier())
                 .toolbar {
                     ToolbarItemGroup {
                         Button {
@@ -595,4 +600,15 @@ struct SessionDetailView: View {
         }
     }
 
+}
+
+/// Glass effect for the session detail header area.
+struct SessionHeaderGlassModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(macOS 26, *) {
+            content.glassEffect(.regular.tint(.clear), in: RoundedRectangle(cornerRadius: DS.Radius.md))
+        } else {
+            content
+        }
+    }
 }

--- a/notetaker/Views/SummaryCardView.swift
+++ b/notetaker/Views/SummaryCardView.swift
@@ -97,6 +97,8 @@ struct SummaryCardView: View {
 
         }
         .padding(.vertical, DS.Spacing.xs)
+        .padding(.horizontal, DS.Spacing.sm)
+        .modifier(SummaryCardGlassModifier(isOverall: isOverall))
         .overlay(alignment: .topTrailing) {
             if !isEditing && !showRegenerateField && (isHovered || showCopiedFeedback) {
                 HStack(spacing: DS.Spacing.xs) {
@@ -270,6 +272,23 @@ struct SummaryCardView: View {
         } else {
             Text(title)
                 .font(DS.Typography.caption)
+        }
+    }
+}
+
+/// Applies tinted glass for overall summaries, regular glass for chunk summaries.
+struct SummaryCardGlassModifier: ViewModifier {
+    let isOverall: Bool
+
+    func body(content: Content) -> some View {
+        if #available(macOS 26, *) {
+            if isOverall {
+                content.glassEffect(.regular.tint(Color.blue.opacity(0.15)), in: RoundedRectangle(cornerRadius: DS.Radius.sm))
+            } else {
+                content.glassEffect(.regular.tint(.clear), in: RoundedRectangle(cornerRadius: DS.Radius.sm))
+            }
+        } else {
+            content
         }
     }
 }

--- a/notetaker/Views/ViewModifiers.swift
+++ b/notetaker/Views/ViewModifiers.swift
@@ -1,21 +1,47 @@
 import SwiftUI
 
 extension View {
-    /// Standard card appearance: padded, rounded, with secondary background.
+    /// Standard card appearance: padded, rounded, with glass on macOS 26+ or secondary background fallback.
     func cardStyle() -> some View {
-        self
-            .padding(DS.Spacing.md)
-            .background(.background.secondary)
-            .clipShape(RoundedRectangle(cornerRadius: DS.Radius.md))
+        modifier(CardStyleModifier())
     }
 
     /// Badge/pill appearance for metadata labels.
     func badgeStyle() -> some View {
-        self
-            .font(DS.Typography.caption2)
-            .padding(.horizontal, DS.Spacing.sm)
-            .padding(.vertical, DS.Spacing.xxs)
-            .background(.quaternary)
-            .clipShape(Capsule())
+        modifier(BadgeStyleModifier())
+    }
+}
+
+struct CardStyleModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(macOS 26, *) {
+            content
+                .padding(DS.Spacing.md)
+                .glassEffect(.regular.tint(.clear), in: RoundedRectangle(cornerRadius: DS.Radius.md))
+        } else {
+            content
+                .padding(DS.Spacing.md)
+                .background(.background.secondary)
+                .clipShape(RoundedRectangle(cornerRadius: DS.Radius.md))
+        }
+    }
+}
+
+struct BadgeStyleModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(macOS 26, *) {
+            content
+                .font(DS.Typography.caption2)
+                .padding(.horizontal, DS.Spacing.sm)
+                .padding(.vertical, DS.Spacing.xxs)
+                .glassEffect(.regular.tint(.clear), in: .capsule)
+        } else {
+            content
+                .font(DS.Typography.caption2)
+                .padding(.horizontal, DS.Spacing.sm)
+                .padding(.vertical, DS.Spacing.xxs)
+                .background(.quaternary)
+                .clipShape(Capsule())
+        }
     }
 }

--- a/notetaker/notetakerApp.swift
+++ b/notetaker/notetakerApp.swift
@@ -175,7 +175,8 @@ struct MenuBarView: View {
                     .foregroundStyle(.secondary)
             }
             .padding(.horizontal, DS.Spacing.md)
-            .padding(.top, DS.Spacing.xs)
+            .padding(.vertical, DS.Spacing.xs)
+            .modifier(MenuBarRecordingGlassModifier(isPaused: false))
             .frame(minWidth: 280)
 
             AudioLevelBar(level: viewModel.audioMeter.level)
@@ -221,6 +222,7 @@ struct MenuBarView: View {
             }
             .padding(.horizontal, DS.Spacing.md)
             .padding(.vertical, DS.Spacing.xs)
+            .modifier(MenuBarRecordingGlassModifier(isPaused: true))
             .frame(minWidth: 280)
 
             Divider()
@@ -280,5 +282,19 @@ struct MenuBarView: View {
             NSApplication.shared.terminate(nil)
         }
         .keyboardShortcut("q")
+    }
+}
+
+/// Glass capsule effect for MenuBarExtra recording/paused status indicators.
+struct MenuBarRecordingGlassModifier: ViewModifier {
+    let isPaused: Bool
+
+    func body(content: Content) -> some View {
+        if #available(macOS 26, *) {
+            let tintColor = isPaused ? Color.orange : Color.red
+            content.glassEffect(.regular.tint(tintColor.opacity(0.2)), in: .capsule)
+        } else {
+            content
+        }
     }
 }

--- a/notetakerTests/LiquidGlassTests.swift
+++ b/notetakerTests/LiquidGlassTests.swift
@@ -1,0 +1,79 @@
+import Testing
+import SwiftUI
+@testable import notetaker
+
+@Suite("Liquid Glass Design Tokens")
+struct LiquidGlassTests {
+
+    // MARK: - DS.Glass smoke tests
+
+    @Test("DS.Glass.card produces a view without crash")
+    func glassCardSmoke() {
+        let view = DS.Glass.card(Text("Hello"), cornerRadius: DS.Radius.md)
+        #expect(type(of: view) != Never.self)
+    }
+
+    @Test("DS.Glass.capsule produces a view without crash")
+    func glassCapsuleSmoke() {
+        let view = DS.Glass.capsule(Text("Badge"))
+        #expect(type(of: view) != Never.self)
+    }
+
+    @Test("DS.Glass.tinted produces a view without crash")
+    func glassTintedSmoke() {
+        let view = DS.Glass.tinted(Text("Tinted"), color: .blue, cornerRadius: DS.Radius.lg)
+        #expect(type(of: view) != Never.self)
+    }
+
+    @Test("DS.Glass.card uses default corner radius from DS.Radius.md")
+    func glassCardDefaultRadius() {
+        // Verify the default parameter matches DS.Radius.md
+        #expect(DS.Radius.md == 8)
+    }
+
+    // MARK: - DS.Radius validation
+
+    @Test("DS.Radius values are positive and ordered")
+    func radiusValuesOrdered() {
+        #expect(DS.Radius.xs > 0)
+        #expect(DS.Radius.sm > DS.Radius.xs)
+        #expect(DS.Radius.md > DS.Radius.sm)
+        #expect(DS.Radius.lg > DS.Radius.md)
+    }
+
+    // MARK: - ViewModifier smoke tests
+
+    @Test("CardStyleModifier can be applied to a View")
+    func cardStyleModifierSmoke() {
+        let view = Text("Card").modifier(CardStyleModifier())
+        #expect(type(of: view) != Never.self)
+    }
+
+    @Test("BadgeStyleModifier can be applied to a View")
+    func badgeStyleModifierSmoke() {
+        let view = Text("Badge").modifier(BadgeStyleModifier())
+        #expect(type(of: view) != Never.self)
+    }
+
+    @Test("SummaryCardGlassModifier can be applied for overall and chunk")
+    func summaryCardGlassModifierSmoke() {
+        let overallView = Text("Overall").modifier(SummaryCardGlassModifier(isOverall: true))
+        let chunkView = Text("Chunk").modifier(SummaryCardGlassModifier(isOverall: false))
+        #expect(type(of: overallView) != Never.self)
+        #expect(type(of: chunkView) != Never.self)
+    }
+
+    @Test("SessionHeaderGlassModifier can be applied")
+    func sessionHeaderGlassModifierSmoke() {
+        let view = Text("Header").modifier(SessionHeaderGlassModifier())
+        #expect(type(of: view) != Never.self)
+    }
+
+    @Test("MenuBarRecordingGlassModifier can be applied for recording and paused")
+    func menuBarGlassModifierSmoke() {
+        let recordingView = Text("Recording").modifier(MenuBarRecordingGlassModifier(isPaused: false))
+        let pausedView = Text("Paused").modifier(MenuBarRecordingGlassModifier(isPaused: true))
+        #expect(type(of: recordingView) != Never.self)
+        #expect(type(of: pausedView) != Never.self)
+    }
+}


### PR DESCRIPTION
## Summary
- `DS.Glass` namespace with `card`/`capsule`/`tinted` glass helper functions, all gated by `#available(macOS 26, *)`
- Updated `.cardStyle()` and `.badgeStyle()` modifiers to use Liquid Glass on macOS 26, with `ultraThinMaterial`/`.background.secondary` fallback
- Glass effects on: `AudioLevelBar` (glass background track), `SummaryCardView` (blue-tinted for overall, clear for chunks), `SessionDetailView` header, `MenuBarView` recording/paused indicators
- Added segment count to session detail header metadata
- 10 smoke tests covering all glass modifiers and DS tokens

Closes #31

## Test plan
- [x] Build succeeds (`CODE_SIGNING_ALLOWED=NO`)
- [x] LiquidGlassTests pass (10/10)
- [ ] Manual: run on macOS 26 — verify glass effects on summary cards, audio bar, session header
- [ ] Manual: verify light/dark mode appearance
- [ ] Manual: verify graceful degradation on macOS 15 (ultraThinMaterial fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)