### PR TITLE
feat: VoiceOver accessibility audit with labels and traits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,14 @@ xcodebuild -scheme notetaker -configuration Debug -only-testing:notetakerUITests
 - **Recurrence mapping**: `CalendarService.mapRecurrenceRule()` maps `EKRecurrenceRule` to `RepeatRule`; only `interval == 1`; weekday detection via `Set<EKWeekday>` equality
 - **SchemaV6**: Adds `calendarEventIdentifier: String? = nil` to `ScheduledRecording`, `scheduledRecordingID: UUID? = nil` to `RecordingSession`
 
+### Accessibility (VoiceOver)
+- `AccessibilityHelpers` (`nonisolated enum` in `Services/`) — pure functions for audio level description, duration formatting, recording state, session description; used by `AudioLevelBar`, `MenuBarView`, `TranscriptSegmentRow`, `SessionListView`
+- `.accessibilityElement(children: .combine)` on composite rows (`TranscriptSegmentRow`, `SessionRowView`); `.accessibilityElement(children: .contain)` on `SummaryCardView`
+- `.accessibilityHidden(true)` on decorative elements (pulsing dot, pause icon, dot separators)
+- `.accessibilityAddTraits(.updatesFrequently)` on real-time data (audio level bar, timer display)
+- `.accessibilityHint` on MenuBarView recording control buttons (start/stop/pause/resume)
+- `.accessibilityLabel` + `.accessibilityAddTraits(.isSelected)` on `DateFilterChip`
+
 ## Architecture
 
 Three-layer architecture: Views → ViewModels → Services, with SwiftData `@Model` classes for persistence.
@@ -139,11 +147,11 @@ Three-layer architecture: Views → ViewModels → Services, with SwiftData `@Mo
   - `notetakerApp.swift` — Entry point, shared `ModelContainer`, `MenuBarExtra`, `Settings` scene
   - `ContentView.swift` — `NavigationSplitView` (sidebar session list + detail routing)
   - `Models/` — SwiftData models (`RecordingSession`, `TranscriptSegment`, `SummaryBlock`, `ScheduledRecording`), config types (`LLMConfig`, `SummarizerConfig`, `LLMModelProfile`, `VADConfig`, `OverallSummaryMode`, `RepeatRule`), ephemeral types (`ChatMessage`), schema versioning (`Schemas/` V1–V6)
-  - `Services/` — Protocol-based engines (`ASREngine`, `LLMEngine`) with multiple implementations (including `FoundationModelsEngine` for Apple Intelligence), `AudioCaptureService`, `AudioPlaybackService`, `AudioExporter`, `SummarizerService`, `BackgroundSummaryService`, `SummaryMarkdownFormatter`, `ChatService`, `PromptBuilder`, `KeychainService`, `CrashLogService`, `SchedulerService`, `CalendarService`
+  - `Services/` — Protocol-based engines (`ASREngine`, `LLMEngine`) with multiple implementations (including `FoundationModelsEngine` for Apple Intelligence), `AudioCaptureService`, `AudioPlaybackService`, `AudioExporter`, `SummarizerService`, `BackgroundSummaryService`, `SummaryMarkdownFormatter`, `ChatService`, `PromptBuilder`, `KeychainService`, `CrashLogService`, `SchedulerService`, `CalendarService`, `AccessibilityHelpers`
   - `ViewModels/` — `RecordingViewModel` (`@Observable`) — central state machine for recording lifecycle; `SchedulerViewModel` — scheduled recordings + calendar integration
   - `DesignSystem.swift` — `DS` enum (spacing, typography, colors, radius, layout tokens)
   - `Views/` — SwiftUI views including `SettingsView` (4-tab layout: `SettingsTab`, `ModelsSettingsTab`, `AboutTab`), `ScheduleView`, `ScheduleEditorView`, `PrivacyDisclosureView`, `SummaryCardView`, `TranscriptSegmentRow`, `AudioLevelBar`, `ResizeHandle`, `VerticalResizeHandle`, `ChatView`, `SettingsComponents` (reusable settings UI), `ViewModifiers`
-- **`notetakerTests/`** — Swift Testing (`@Test`, `#expect`); ~64 test files; `Mocks/` has `MockASREngine`, `MockLLMEngine`, `MockSchedulerService`, per-suite `MockURLProtocol` subclasses; `Helpers/` has `BufferFactory` and `FileAudioSource`
+- **`notetakerTests/`** — Swift Testing (`@Test`, `#expect`); ~65 test files; `Mocks/` has `MockASREngine`, `MockLLMEngine`, `MockSchedulerService`, per-suite `MockURLProtocol` subclasses; `Helpers/` has `BufferFactory` and `FileAudioSource`
 - **`notetakerUITests/`** — XCTest UI tests (light/dark mode via `runsForEachTargetApplicationUIConfiguration`)
 - **`scripts/`** — `increment_build_number.sh`
 - **`docs/`** — `PRIVACY_POLICY.md`, `APP_STORE_PRIVACY_CHECKLIST.md`, specs (SPEC-001 through SPEC-005)

--- a/UnitTests.xctestplan
+++ b/UnitTests.xctestplan
@@ -18,6 +18,7 @@
         "name" : "notetakerTests"
       },
       "selectedTests" : [
+        "AccessibilityHelpersTests",
         "AudioConfigTests",
         "ChatServiceTests",
         "AudioExporterTests",

--- a/notetaker/Services/AccessibilityHelpers.swift
+++ b/notetaker/Services/AccessibilityHelpers.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Pure functions for generating accessibility descriptions.
+nonisolated enum AccessibilityHelpers {
+    /// Describe audio level for VoiceOver.
+    static func audioLevelDescription(_ level: Float) -> String {
+        switch level {
+        case ..<0.05: return "Silent"
+        case 0.05..<0.2: return "Quiet"
+        case 0.2..<0.5: return "Moderate"
+        case 0.5..<0.8: return "Loud"
+        default: return "Very loud"
+        }
+    }
+
+    /// Format duration for VoiceOver reading: "5 minutes, 30 seconds"
+    static func durationDescription(_ seconds: TimeInterval) -> String {
+        let totalSeconds = Int(seconds)
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let secs = totalSeconds % 60
+
+        var parts: [String] = []
+        if hours > 0 { parts.append("\(hours) hour\(hours == 1 ? "" : "s")") }
+        if minutes > 0 { parts.append("\(minutes) minute\(minutes == 1 ? "" : "s")") }
+        if secs > 0 || parts.isEmpty { parts.append("\(secs) second\(secs == 1 ? "" : "s")") }
+
+        return parts.joined(separator: ", ")
+    }
+
+    /// Format timestamp for VoiceOver: "at 5 minutes 30 seconds"
+    static func timestampDescription(_ seconds: TimeInterval) -> String {
+        "at \(durationDescription(seconds))"
+    }
+
+    /// Describe recording state.
+    static func recordingStateDescription(isRecording: Bool, isPaused: Bool, elapsed: TimeInterval) -> String {
+        if isPaused {
+            return "Recording paused at \(durationDescription(elapsed))"
+        } else if isRecording {
+            return "Recording in progress, \(durationDescription(elapsed)) elapsed"
+        } else {
+            return "Not recording"
+        }
+    }
+
+    /// Describe session for VoiceOver.
+    static func sessionDescription(title: String, date: Date, duration: TimeInterval, segmentCount: Int) -> String {
+        let dateStr = date.formatted(date: .abbreviated, time: .shortened)
+        let durStr = durationDescription(duration)
+        return "\(title), recorded \(dateStr), duration \(durStr), \(segmentCount) transcript segment\(segmentCount == 1 ? "" : "s")"
+    }
+}

--- a/notetaker/Views/AudioLevelBar.swift
+++ b/notetaker/Views/AudioLevelBar.swift
@@ -16,7 +16,9 @@ struct AudioLevelBar: View {
         }
         .frame(height: DS.Spacing.xs)
         .animation(.linear(duration: 0.05), value: level)
+        .accessibilityElement()
         .accessibilityLabel("Audio level")
-        .accessibilityValue("\(Int(level * 100)) percent")
+        .accessibilityValue(AccessibilityHelpers.audioLevelDescription(level))
+        .accessibilityAddTraits(.updatesFrequently)
     }
 }

--- a/notetaker/Views/SessionListView.swift
+++ b/notetaker/Views/SessionListView.swift
@@ -200,16 +200,18 @@ private struct SessionRowView: View {
                     .foregroundStyle(.secondary)
 
                 if session.totalDuration > 0 {
-                    Text("·")
+                    Text("\u{00B7}")
                         .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
                     Text(session.totalDuration.compactDuration)
                         .font(DS.Typography.caption)
                         .foregroundStyle(.secondary)
                 }
 
                 if !session.segments.isEmpty {
-                    Text("·")
+                    Text("\u{00B7}")
                         .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
                     Text("\(session.segments.count) segments")
                         .font(DS.Typography.caption)
                         .foregroundStyle(.secondary)
@@ -280,5 +282,7 @@ private struct DateFilterChip: View {
                 .contentShape(Capsule())
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("\(label) filter")
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
     }
 }

--- a/notetaker/Views/SummaryCardView.swift
+++ b/notetaker/Views/SummaryCardView.swift
@@ -97,6 +97,7 @@ struct SummaryCardView: View {
 
         }
         .padding(.vertical, DS.Spacing.xs)
+        .accessibilityElement(children: .contain)
         .overlay(alignment: .topTrailing) {
             if !isEditing && !showRegenerateField && (isHovered || showCopiedFeedback) {
                 HStack(spacing: DS.Spacing.xs) {
@@ -113,6 +114,7 @@ struct SummaryCardView: View {
                         .buttonStyle(.plain)
                         .foregroundStyle(.tertiary)
                         .help("Edit summary")
+                        .accessibilityLabel("Edit summary")
                     }
                     if onRegenerate != nil {
                         Button {
@@ -125,6 +127,7 @@ struct SummaryCardView: View {
                         .buttonStyle(.plain)
                         .foregroundStyle(.tertiary)
                         .help("Regenerate with instructions")
+                        .accessibilityLabel("Regenerate summary")
                     }
                 }
             }

--- a/notetaker/Views/TranscriptSegmentRow.swift
+++ b/notetaker/Views/TranscriptSegmentRow.swift
@@ -15,5 +15,6 @@ struct TranscriptSegmentRow: View {
         }
         .padding(.vertical, DS.Spacing.xxs)
         .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(AccessibilityHelpers.timestampDescription(segment.startTime)), \(segment.text)")
     }
 }

--- a/notetaker/notetakerApp.swift
+++ b/notetaker/notetakerApp.swift
@@ -167,16 +167,21 @@ struct MenuBarView: View {
                     .animation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true), value: pulsing)
                     .onAppear { pulsing = true }
                     .onDisappear { pulsing = false }
+                    .accessibilityHidden(true)
                 Text("Recording")
                     .fontWeight(.medium)
                 Spacer()
                 Text(viewModel.clock.formatted)
                     .font(.system(.body, design: .monospaced))
                     .foregroundStyle(.secondary)
+                    .accessibilityLabel(AccessibilityHelpers.durationDescription(viewModel.clock.elapsedTime))
+                    .accessibilityAddTraits(.updatesFrequently)
             }
             .padding(.horizontal, DS.Spacing.md)
             .padding(.top, DS.Spacing.xs)
             .frame(minWidth: 280)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(AccessibilityHelpers.recordingStateDescription(isRecording: true, isPaused: false, elapsed: viewModel.clock.elapsedTime))
 
             AudioLevelBar(level: viewModel.audioMeter.level)
                 .padding(.horizontal, DS.Spacing.md)
@@ -202,26 +207,32 @@ struct MenuBarView: View {
             } label: {
                 Label("Pause Recording", systemImage: "pause.fill")
             }
+            .accessibilityHint("Pauses the current recording")
 
             Button(role: .destructive) {
                 viewModel.stopRecording(modelContext: modelContainer.mainContext)
             } label: {
                 Label("Stop Recording", systemImage: "stop.fill")
             }
+            .accessibilityHint("Stops and saves the current recording")
         } else if viewModel.state == .paused {
             HStack(spacing: DS.Spacing.xs) {
                 Image(systemName: "pause.circle.fill")
                     .foregroundStyle(.orange)
+                    .accessibilityHidden(true)
                 Text("Paused")
                     .fontWeight(.medium)
                 Spacer()
                 Text(viewModel.clock.formatted)
                     .font(.system(.body, design: .monospaced))
                     .foregroundStyle(.secondary)
+                    .accessibilityLabel(AccessibilityHelpers.durationDescription(viewModel.clock.elapsedTime))
             }
             .padding(.horizontal, DS.Spacing.md)
             .padding(.vertical, DS.Spacing.xs)
             .frame(minWidth: 280)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(AccessibilityHelpers.recordingStateDescription(isRecording: false, isPaused: true, elapsed: viewModel.clock.elapsedTime))
 
             Divider()
 
@@ -230,12 +241,14 @@ struct MenuBarView: View {
             } label: {
                 Label("Resume Recording", systemImage: "play.fill")
             }
+            .accessibilityHint("Resumes the paused recording")
 
             Button(role: .destructive) {
                 viewModel.stopRecording(modelContext: modelContainer.mainContext)
             } label: {
                 Label("Stop Recording", systemImage: "stop.fill")
             }
+            .accessibilityHint("Stops and saves the current recording")
         } else {
             Label("Not Recording", systemImage: "mic.slash")
                 .foregroundStyle(.secondary)
@@ -264,6 +277,7 @@ struct MenuBarView: View {
             } label: {
                 Label("Start Recording", systemImage: "record.circle")
             }
+            .accessibilityHint("Starts a new audio recording session")
         }
 
         Divider()

--- a/notetakerTests/AccessibilityHelpersTests.swift
+++ b/notetakerTests/AccessibilityHelpersTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+@testable import notetaker
+
+struct AccessibilityHelpersTests {
+    // MARK: - audioLevelDescription
+
+    @Test func audioLevelSilent() {
+        #expect(AccessibilityHelpers.audioLevelDescription(0.0) == "Silent")
+        #expect(AccessibilityHelpers.audioLevelDescription(0.04) == "Silent")
+    }
+
+    @Test func audioLevelQuiet() {
+        #expect(AccessibilityHelpers.audioLevelDescription(0.05) == "Quiet")
+        #expect(AccessibilityHelpers.audioLevelDescription(0.19) == "Quiet")
+    }
+
+    @Test func audioLevelModerate() {
+        #expect(AccessibilityHelpers.audioLevelDescription(0.2) == "Moderate")
+        #expect(AccessibilityHelpers.audioLevelDescription(0.49) == "Moderate")
+    }
+
+    @Test func audioLevelLoud() {
+        #expect(AccessibilityHelpers.audioLevelDescription(0.5) == "Loud")
+        #expect(AccessibilityHelpers.audioLevelDescription(0.79) == "Loud")
+    }
+
+    @Test func audioLevelVeryLoud() {
+        #expect(AccessibilityHelpers.audioLevelDescription(0.8) == "Very loud")
+        #expect(AccessibilityHelpers.audioLevelDescription(1.0) == "Very loud")
+    }
+
+    // MARK: - durationDescription
+
+    @Test func durationZeroSeconds() {
+        #expect(AccessibilityHelpers.durationDescription(0) == "0 seconds")
+    }
+
+    @Test func durationSecondsOnly() {
+        #expect(AccessibilityHelpers.durationDescription(45) == "45 seconds")
+    }
+
+    @Test func durationSingularSecond() {
+        #expect(AccessibilityHelpers.durationDescription(1) == "1 second")
+    }
+
+    @Test func durationMinutesAndSeconds() {
+        #expect(AccessibilityHelpers.durationDescription(330) == "5 minutes, 30 seconds")
+    }
+
+    @Test func durationSingularMinute() {
+        #expect(AccessibilityHelpers.durationDescription(90) == "1 minute, 30 seconds")
+    }
+
+    @Test func durationHoursMinutesSeconds() {
+        #expect(AccessibilityHelpers.durationDescription(3661) == "1 hour, 1 minute, 1 second")
+    }
+
+    @Test func durationMultipleHours() {
+        #expect(AccessibilityHelpers.durationDescription(7384) == "2 hours, 3 minutes, 4 seconds")
+    }
+
+    @Test func durationExactMinutes() {
+        #expect(AccessibilityHelpers.durationDescription(120) == "2 minutes")
+    }
+
+    // MARK: - timestampDescription
+
+    @Test func timestampDescription() {
+        #expect(AccessibilityHelpers.timestampDescription(330) == "at 5 minutes, 30 seconds")
+    }
+
+    // MARK: - recordingStateDescription
+
+    @Test func recordingStateRecording() {
+        let result = AccessibilityHelpers.recordingStateDescription(isRecording: true, isPaused: false, elapsed: 65)
+        #expect(result == "Recording in progress, 1 minute, 5 seconds elapsed")
+    }
+
+    @Test func recordingStatePaused() {
+        let result = AccessibilityHelpers.recordingStateDescription(isRecording: false, isPaused: true, elapsed: 30)
+        #expect(result == "Recording paused at 30 seconds")
+    }
+
+    @Test func recordingStateIdle() {
+        let result = AccessibilityHelpers.recordingStateDescription(isRecording: false, isPaused: false, elapsed: 0)
+        #expect(result == "Not recording")
+    }
+
+    // MARK: - sessionDescription
+
+    @Test func sessionDescriptionFull() {
+        let date = Date(timeIntervalSince1970: 1700000000) // Fixed date for deterministic test
+        let result = AccessibilityHelpers.sessionDescription(
+            title: "Team Meeting",
+            date: date,
+            duration: 1830,
+            segmentCount: 42
+        )
+        #expect(result.hasPrefix("Team Meeting, recorded "))
+        #expect(result.contains("duration 30 minutes, 30 seconds"))
+        #expect(result.hasSuffix("42 transcript segments"))
+    }
+
+    @Test func sessionDescriptionSingularSegment() {
+        let date = Date(timeIntervalSince1970: 1700000000)
+        let result = AccessibilityHelpers.sessionDescription(
+            title: "Quick Note",
+            date: date,
+            duration: 10,
+            segmentCount: 1
+        )
+        #expect(result.hasSuffix("1 transcript segment"))
+    }
+}


### PR DESCRIPTION
## Summary
- `AccessibilityHelpers` (nonisolated enum) — pure functions for audio level description, duration formatting, recording state, session description
- AudioLevelBar: `accessibilityElement` with descriptive level text (Silent/Quiet/Moderate/Loud/Very loud), `updatesFrequently` trait
- SummaryCardView: `accessibilityLabel` on edit and regenerate action buttons, `accessibilityElement(children: .contain)` on card
- TranscriptSegmentRow: explicit `accessibilityLabel` combining spoken timestamp + text
- MenuBarView: `accessibilityLabel` and `accessibilityHint` on all recording controls (start/stop/pause/resume), state descriptions on status bars, `accessibilityHidden` on decorative icons
- SessionListView: `accessibilityHidden` on dot separators, `accessibilityLabel` + `isSelected` trait on date filter chips
- 19 unit tests covering all `AccessibilityHelpers` functions

Closes #37

## Test plan
- [x] Build succeeds
- [x] Unit tests pass (19/19)
- [ ] Manual: enable VoiceOver → navigate through recording controls → verify all buttons announced
- [ ] Manual: VoiceOver on session list → verify session title/date/duration read correctly
- [ ] Manual: VoiceOver on audio level bar → verify level description updates
- [ ] Manual: VoiceOver on summary cards → verify edit/regenerate/copy buttons announced