### PR TITLE
feat: meeting templates and workflow presets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,12 @@ xcodebuild -scheme notetaker -configuration Debug -only-testing:notetakerUITests
 - **Recurrence mapping**: `CalendarService.mapRecurrenceRule()` maps `EKRecurrenceRule` to `RepeatRule`; only `interval == 1`; weekday detection via `Set<EKWeekday>` equality
 - **SchemaV6**: Adds `calendarEventIdentifier: String? = nil` to `ScheduledRecording`, `scheduledRecordingID: UUID? = nil` to `RecordingSession`
 
+### Meeting Templates
+- **`MeetingTemplate`**: `nonisolated struct: Identifiable, Codable, Sendable, Hashable` — reusable workflow presets with name, icon, description, optional summarization overrides (interval, style, language), optional linked IDs (aiRecipeID, llmProfileID), and suggestedDurationMinutes
+- **`MeetingTemplateStore`**: `nonisolated enum` — JSON file storage at `~/Library/Application Support/notetaker/templates.json`; 5 built-in templates with stable UUIDs (General Meeting, Standup/Sync, 1-on-1, Brainstorm, Lecture/Talk); built-ins cannot be deleted; `loadTemplates()` always ensures built-ins present; `duplicateTemplate()` creates editable copy
+- **`TemplatePickerView`**: Sheet shown before recording starts (controlled by `@AppStorage("showTemplatePickerOnRecord")`); grid of template cards; skip button for default recording; applies template overrides to `SummarizerConfig` in UserDefaults before `startRecording()`
+- **`TemplateManagerView`**: Settings tab for template CRUD; HSplitView with list + detail; built-in templates are read-only with duplicate option; custom templates fully editable
+
 ## Architecture
 
 Three-layer architecture: Views → ViewModels → Services, with SwiftData `@Model` classes for persistence.
@@ -138,11 +144,11 @@ Three-layer architecture: Views → ViewModels → Services, with SwiftData `@Mo
 - **`notetaker/`** — Main app target
   - `notetakerApp.swift` — Entry point, shared `ModelContainer`, `MenuBarExtra`, `Settings` scene
   - `ContentView.swift` — `NavigationSplitView` (sidebar session list + detail routing)
-  - `Models/` — SwiftData models (`RecordingSession`, `TranscriptSegment`, `SummaryBlock`, `ScheduledRecording`), config types (`LLMConfig`, `SummarizerConfig`, `LLMModelProfile`, `VADConfig`, `OverallSummaryMode`, `RepeatRule`), ephemeral types (`ChatMessage`), schema versioning (`Schemas/` V1–V6)
-  - `Services/` — Protocol-based engines (`ASREngine`, `LLMEngine`) with multiple implementations (including `FoundationModelsEngine` for Apple Intelligence), `AudioCaptureService`, `AudioPlaybackService`, `AudioExporter`, `SummarizerService`, `BackgroundSummaryService`, `SummaryMarkdownFormatter`, `ChatService`, `PromptBuilder`, `KeychainService`, `CrashLogService`, `SchedulerService`, `CalendarService`
+  - `Models/` — SwiftData models (`RecordingSession`, `TranscriptSegment`, `SummaryBlock`, `ScheduledRecording`), config types (`LLMConfig`, `SummarizerConfig`, `LLMModelProfile`, `VADConfig`, `OverallSummaryMode`, `RepeatRule`, `MeetingTemplate`), ephemeral types (`ChatMessage`), schema versioning (`Schemas/` V1–V6)
+  - `Services/` — Protocol-based engines (`ASREngine`, `LLMEngine`) with multiple implementations (including `FoundationModelsEngine` for Apple Intelligence), `AudioCaptureService`, `AudioPlaybackService`, `AudioExporter`, `SummarizerService`, `BackgroundSummaryService`, `SummaryMarkdownFormatter`, `ChatService`, `PromptBuilder`, `KeychainService`, `CrashLogService`, `SchedulerService`, `CalendarService`, `MeetingTemplateStore`
   - `ViewModels/` — `RecordingViewModel` (`@Observable`) — central state machine for recording lifecycle; `SchedulerViewModel` — scheduled recordings + calendar integration
   - `DesignSystem.swift` — `DS` enum (spacing, typography, colors, radius, layout tokens)
-  - `Views/` — SwiftUI views including `SettingsView` (4-tab layout: `SettingsTab`, `ModelsSettingsTab`, `AboutTab`), `ScheduleView`, `ScheduleEditorView`, `PrivacyDisclosureView`, `SummaryCardView`, `TranscriptSegmentRow`, `AudioLevelBar`, `ResizeHandle`, `VerticalResizeHandle`, `ChatView`, `SettingsComponents` (reusable settings UI), `ViewModifiers`
+  - `Views/` — SwiftUI views including `SettingsView` (6-tab layout: Models, LLM, Summarization, Recording, Templates, About), `ScheduleView`, `ScheduleEditorView`, `PrivacyDisclosureView`, `SummaryCardView`, `TranscriptSegmentRow`, `AudioLevelBar`, `ResizeHandle`, `VerticalResizeHandle`, `ChatView`, `TemplatePickerView`, `TemplateManagerView`, `SettingsComponents` (reusable settings UI), `ViewModifiers`
 - **`notetakerTests/`** — Swift Testing (`@Test`, `#expect`); ~64 test files; `Mocks/` has `MockASREngine`, `MockLLMEngine`, `MockSchedulerService`, per-suite `MockURLProtocol` subclasses; `Helpers/` has `BufferFactory` and `FileAudioSource`
 - **`notetakerUITests/`** — XCTest UI tests (light/dark mode via `runsForEachTargetApplicationUIConfiguration`)
 - **`scripts/`** — `increment_build_number.sh`
@@ -162,9 +168,9 @@ Three-layer architecture: Views → ViewModels → Services, with SwiftData `@Mo
 - `DispatchQueue.main.asyncAfter` may not fire during `Task.sleep`-based polling in Swift Testing — use `DispatchQueue.global()` or avoid dispatch
 - UI launch tests use `runsForEachTargetApplicationUIConfiguration = true` to test light/dark mode; do NOT delete
 - **Close the app before running tests** — if the app is already running, UI tests attach to the existing instance instead of launching a fresh one, causing `Failed to terminate` errors and test failures
-- **Two-tier test plans**: `UnitTests.xctestplan` (22 pure-logic suites, ~257 tests, <0.2s) is default for Cmd+U; `FullTests.xctestplan` (all suites + UI tests) for CI on PR to main; shared scheme at `xcshareddata/xcschemes/notetaker.xcscheme` associates both plans
+- **Two-tier test plans**: `UnitTests.xctestplan` (23 pure-logic suites, ~269 tests, <0.2s) is default for Cmd+U; `FullTests.xctestplan` (all suites + UI tests) for CI on PR to main; shared scheme at `xcshareddata/xcschemes/notetaker.xcscheme` associates both plans
 - **Test plan gotcha**: Xcode auto-generated schemes don't support `-testPlan`; the explicit shared scheme with `shouldAutocreateTestPlan = "NO"` is required; verify with `xcodebuild -scheme notetaker -showTestPlans`
-- 31 test suites use `.serialized` to prevent parallel UserDefaults/Keychain/URLProtocol/SwiftData/NSPasteboard contamination; ~746 tests total across ~64 test files; UnitTests plan excludes all serialized suites for fast local iteration
+- 31 test suites use `.serialized` to prevent parallel UserDefaults/Keychain/URLProtocol/SwiftData/NSPasteboard contamination; ~758 tests total across ~65 test files; UnitTests plan excludes all serialized suites for fast local iteration
 
 ## CI Workflows
 

--- a/UnitTests.xctestplan
+++ b/UnitTests.xctestplan
@@ -29,6 +29,7 @@
         "LLMHTTPHelpersTests",
         "LLMModelProfileCoverageTests",
         "LLMModelProfileTests",
+        "MeetingTemplateTests",
         "LLMProviderCoverageTests",
         "LLMProviderTests",
         "LLMRoleCoverageTests",

--- a/notetaker/ContentView.swift
+++ b/notetaker/ContentView.swift
@@ -1,12 +1,17 @@
 import SwiftUI
 import SwiftData
+import os
 
 struct ContentView: View {
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "notetaker", category: "ContentView")
+
     @Environment(\.modelContext) private var modelContext
     @Bindable var viewModel: RecordingViewModel
     var schedulerViewModel: SchedulerViewModel
     @State private var selectedSessionID: UUID?
     @State private var showScheduleSheet = false
+    @State private var showTemplatePicker = false
+    @AppStorage("showTemplatePickerOnRecord") private var showTemplatePickerOnRecord = true
 
     /// Handle recording completion — works both on initial appear and state change.
     /// Background summary is already dispatched by the ViewModel's drainTask.
@@ -25,9 +30,10 @@ struct ContentView: View {
                 .toolbar {
                     ToolbarItem(placement: .primaryAction) {
                         Button {
-                            selectedSessionID = nil
-                            Task {
-                                await viewModel.startRecording(modelContext: modelContext)
+                            if showTemplatePickerOnRecord {
+                                showTemplatePicker = true
+                            } else {
+                                startRecordingWithDefaults()
                             }
                         } label: {
                             Image(systemName: "plus")
@@ -48,6 +54,11 @@ struct ContentView: View {
                 .sheet(isPresented: $showScheduleSheet) {
                     ScheduleView(schedulerViewModel: schedulerViewModel)
                         .frame(minWidth: 480, minHeight: 400)
+                }
+                .sheet(isPresented: $showTemplatePicker) {
+                    TemplatePickerView { template in
+                        startRecordingWithTemplate(template)
+                    }
                 }
         } detail: {
             if viewModel.isActive || viewModel.state == .stopping {
@@ -84,6 +95,56 @@ struct ContentView: View {
         .onChange(of: viewModel.state) { _, newState in
             if newState == .completed {
                 handleCompletionIfNeeded()
+            }
+        }
+    }
+
+    // MARK: - Template Recording
+
+    private func startRecordingWithDefaults() {
+        selectedSessionID = nil
+        Task { @MainActor in
+            await viewModel.startRecording(modelContext: modelContext)
+        }
+    }
+
+    private func startRecordingWithTemplate(_ template: MeetingTemplate?) {
+        selectedSessionID = nil
+        if let template {
+            applyTemplateOverrides(template)
+            Self.logger.info("Starting recording with template: \(template.name)")
+        } else {
+            Self.logger.info("Starting recording without template (skipped)")
+        }
+        Task { @MainActor in
+            await viewModel.startRecording(modelContext: modelContext)
+        }
+    }
+
+    /// Applies template overrides to UserDefaults-based summarizer config before recording starts.
+    /// The RecordingViewModel reads config from UserDefaults at init, so we update it in-place.
+    private func applyTemplateOverrides(_ template: MeetingTemplate) {
+        var config = SummarizerConfig.fromUserDefaults()
+        var changed = false
+
+        if let interval = template.summaryIntervalMinutes {
+            config.intervalMinutes = interval
+            changed = true
+        }
+        if let styleRaw = template.summaryStyle, let style = SummaryStyle(rawValue: styleRaw) {
+            config.summaryStyle = style
+            changed = true
+        }
+        if let language = template.language {
+            config.summaryLanguage = language
+            changed = true
+        }
+
+        if changed {
+            if let data = try? JSONEncoder().encode(config),
+               let json = String(data: data, encoding: .utf8) {
+                UserDefaults.standard.set(json, forKey: "summarizerConfigJSON")
+                Self.logger.info("Applied template overrides: interval=\(config.intervalMinutes), style=\(config.summaryStyle.rawValue), language=\(config.summaryLanguage)")
             }
         }
     }

--- a/notetaker/Models/MeetingTemplate.swift
+++ b/notetaker/Models/MeetingTemplate.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// A reusable meeting workflow preset that configures recording, summarization, and automation.
+nonisolated struct MeetingTemplate: Identifiable, Codable, Sendable, Hashable {
+    let id: UUID
+    var name: String
+    var icon: String  // SF Symbol name
+    var description: String
+    var isBuiltIn: Bool
+
+    // Summarization overrides
+    var summaryIntervalMinutes: Int?  // Override periodic summary interval
+    var summaryStyle: String?         // SummaryStyle raw value
+    var language: String?             // Override language
+
+    // Optional linked IDs (resolved at apply time if features available)
+    var aiRecipeID: UUID?
+    var llmProfileID: UUID?
+
+    // Recording hints
+    var suggestedDurationMinutes: Int?
+
+    var createdAt: Date
+    var updatedAt: Date
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        icon: String,
+        description: String,
+        isBuiltIn: Bool = false,
+        summaryIntervalMinutes: Int? = nil,
+        summaryStyle: String? = nil,
+        language: String? = nil,
+        aiRecipeID: UUID? = nil,
+        llmProfileID: UUID? = nil,
+        suggestedDurationMinutes: Int? = nil,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.icon = icon
+        self.description = description
+        self.isBuiltIn = isBuiltIn
+        self.summaryIntervalMinutes = summaryIntervalMinutes
+        self.summaryStyle = summaryStyle
+        self.language = language
+        self.aiRecipeID = aiRecipeID
+        self.llmProfileID = llmProfileID
+        self.suggestedDurationMinutes = suggestedDurationMinutes
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}

--- a/notetaker/Services/MeetingTemplateStore.swift
+++ b/notetaker/Services/MeetingTemplateStore.swift
@@ -1,0 +1,127 @@
+import Foundation
+import os
+
+/// Manages persistence and CRUD for meeting templates.
+/// Built-in templates are always present; custom templates stored as JSON.
+nonisolated enum MeetingTemplateStore {
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "notetaker",
+        category: "MeetingTemplateStore"
+    )
+
+    static var storageURL: URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let dir = appSupport.appendingPathComponent("notetaker", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("templates.json")
+    }
+
+    // MARK: - CRUD
+
+    static func loadTemplates() -> [MeetingTemplate] {
+        var templates = loadFromFile()
+        // Ensure built-ins are present
+        for builtIn in builtInTemplates {
+            if !templates.contains(where: { $0.id == builtIn.id }) {
+                templates.insert(builtIn, at: 0)
+            }
+        }
+        logger.debug("Loaded \(templates.count) meeting templates")
+        return templates.sorted { lhs, rhs in
+            if lhs.isBuiltIn != rhs.isBuiltIn { return lhs.isBuiltIn }
+            return lhs.name < rhs.name
+        }
+    }
+
+    static func saveTemplates(_ templates: [MeetingTemplate]) {
+        do {
+            let data = try JSONEncoder().encode(templates)
+            try data.write(to: storageURL, options: .atomic)
+            logger.info("Saved \(templates.count) meeting templates")
+        } catch {
+            logger.error("Failed to save meeting templates: \(error.localizedDescription)")
+        }
+    }
+
+    static func deleteTemplate(id: UUID, from templates: inout [MeetingTemplate]) {
+        templates.removeAll { $0.id == id && !$0.isBuiltIn }
+    }
+
+    static func duplicateTemplate(_ template: MeetingTemplate) -> MeetingTemplate {
+        MeetingTemplate(
+            name: "\(template.name) (Copy)",
+            icon: template.icon,
+            description: template.description,
+            isBuiltIn: false,
+            summaryIntervalMinutes: template.summaryIntervalMinutes,
+            summaryStyle: template.summaryStyle,
+            language: template.language,
+            aiRecipeID: template.aiRecipeID,
+            llmProfileID: template.llmProfileID,
+            suggestedDurationMinutes: template.suggestedDurationMinutes
+        )
+    }
+
+    // MARK: - Private
+
+    private static func loadFromFile() -> [MeetingTemplate] {
+        guard let data = try? Data(contentsOf: storageURL),
+              let templates = try? JSONDecoder().decode([MeetingTemplate].self, from: data) else {
+            return []
+        }
+        return templates
+    }
+
+    // MARK: - Built-in Templates (stable UUIDs)
+
+    static let builtInTemplates: [MeetingTemplate] = [
+        MeetingTemplate(
+            id: UUID(uuidString: "A0000001-0000-0000-0000-000000000001")!,
+            name: "General Meeting",
+            icon: "person.3",
+            description: "Standard meeting with key points, decisions, and action items",
+            isBuiltIn: true,
+            summaryIntervalMinutes: 10,
+            summaryStyle: "bullets"
+        ),
+        MeetingTemplate(
+            id: UUID(uuidString: "A0000001-0000-0000-0000-000000000002")!,
+            name: "Standup / Sync",
+            icon: "list.clipboard",
+            description: "Quick sync with blockers and action items (15-30 min)",
+            isBuiltIn: true,
+            summaryIntervalMinutes: 5,
+            summaryStyle: "bullets",
+            suggestedDurationMinutes: 15
+        ),
+        MeetingTemplate(
+            id: UUID(uuidString: "A0000001-0000-0000-0000-000000000003")!,
+            name: "1-on-1",
+            icon: "person.2",
+            description: "One-on-one with status, blockers, and career development",
+            isBuiltIn: true,
+            summaryIntervalMinutes: 15,
+            summaryStyle: "bullets",
+            suggestedDurationMinutes: 30
+        ),
+        MeetingTemplate(
+            id: UUID(uuidString: "A0000001-0000-0000-0000-000000000004")!,
+            name: "Brainstorm",
+            icon: "lightbulb",
+            description: "Creative session — capture ideas, group themes, identify next steps",
+            isBuiltIn: true,
+            summaryIntervalMinutes: 15,
+            summaryStyle: "actionItems"
+        ),
+        MeetingTemplate(
+            id: UUID(uuidString: "A0000001-0000-0000-0000-000000000005")!,
+            name: "Lecture / Talk",
+            icon: "graduationcap",
+            description: "Long-form content — larger summary chunks, detailed notes",
+            isBuiltIn: true,
+            summaryIntervalMinutes: 30,
+            summaryStyle: "paragraph",
+            suggestedDurationMinutes: 60
+        ),
+    ]
+}

--- a/notetaker/Views/SettingsView.swift
+++ b/notetaker/Views/SettingsView.swift
@@ -18,6 +18,9 @@ struct SettingsView: View {
             RecordingSettingsTab()
                 .tabItem { Label("Recording", systemImage: "mic") }
 
+            TemplateManagerView()
+                .tabItem { Label("Templates", systemImage: "doc.text") }
+
             AboutTab()
                 .tabItem { Label("About", systemImage: "info.circle") }
         }

--- a/notetaker/Views/TemplateManagerView.swift
+++ b/notetaker/Views/TemplateManagerView.swift
@@ -1,0 +1,270 @@
+import SwiftUI
+import os
+
+/// Settings tab for managing meeting templates (built-in and custom).
+struct TemplateManagerView: View {
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "notetaker",
+        category: "TemplateManagerView"
+    )
+
+    @State private var templates: [MeetingTemplate] = []
+    @State private var selectedTemplateID: UUID?
+    @State private var showDeleteConfirmation = false
+    @AppStorage("showTemplatePickerOnRecord") private var showPickerOnRecord = true
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Toggle for template picker on record
+            HStack {
+                Toggle("Show template picker when starting a recording", isOn: $showPickerOnRecord)
+                    .font(DS.Typography.callout)
+                Spacer()
+            }
+            .padding(.horizontal, DS.Spacing.md)
+            .padding(.vertical, DS.Spacing.sm)
+
+            Divider()
+
+            HSplitView {
+                templateList
+                    .frame(minWidth: 200, idealWidth: 220)
+
+                templateDetail
+                    .frame(minWidth: 300)
+            }
+        }
+        .onAppear {
+            templates = MeetingTemplateStore.loadTemplates()
+        }
+    }
+
+    // MARK: - Template List
+
+    private var templateList: some View {
+        VStack(spacing: 0) {
+            List(selection: $selectedTemplateID) {
+                Section("Built-in") {
+                    ForEach(templates.filter(\.isBuiltIn)) { template in
+                        templateRow(template)
+                    }
+                }
+                if templates.contains(where: { !$0.isBuiltIn }) {
+                    Section("Custom") {
+                        ForEach(templates.filter { !$0.isBuiltIn }) { template in
+                            templateRow(template)
+                        }
+                    }
+                }
+            }
+
+            Divider()
+
+            HStack(spacing: DS.Spacing.sm) {
+                Button(action: addTemplate) {
+                    Image(systemName: "plus")
+                }
+                .help("Add custom template")
+
+                Button(action: { showDeleteConfirmation = true }) {
+                    Image(systemName: "minus")
+                }
+                .disabled(selectedIsBuiltIn)
+                .help("Delete selected template")
+
+                if let selected = selectedTemplate {
+                    Button(action: { duplicateSelected(selected) }) {
+                        Image(systemName: "doc.on.doc")
+                    }
+                    .help("Duplicate template")
+                }
+
+                Spacer()
+            }
+            .padding(DS.Spacing.sm)
+        }
+        .confirmationDialog(
+            "Delete this template?",
+            isPresented: $showDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                deleteSelected()
+            }
+        }
+    }
+
+    private func templateRow(_ template: MeetingTemplate) -> some View {
+        Label {
+            Text(template.name)
+                .lineLimit(1)
+        } icon: {
+            Image(systemName: template.icon)
+        }
+        .tag(template.id)
+    }
+
+    // MARK: - Template Detail
+
+    @ViewBuilder
+    private var templateDetail: some View {
+        if let index = selectedTemplateIndex {
+            let isBuiltIn = templates[index].isBuiltIn
+            ScrollView {
+                VStack(spacing: DS.Spacing.lg) {
+                    SettingsGrid {
+                        SettingsRow("Name") {
+                            TextField("Template name", text: $templates[index].name)
+                                .disabled(isBuiltIn)
+                        }
+
+                        SettingsRow("Icon") {
+                            TextField("SF Symbol name", text: $templates[index].icon)
+                                .disabled(isBuiltIn)
+                        }
+
+                        SettingsRow("Description") {
+                            TextField("Description", text: $templates[index].description, axis: .vertical)
+                                .lineLimit(2...4)
+                                .disabled(isBuiltIn)
+                        }
+
+                        SettingsRow("Summary Interval") {
+                            OptionalIntField(
+                                value: $templates[index].summaryIntervalMinutes,
+                                placeholder: "Default",
+                                suffix: "min"
+                            )
+                            .disabled(isBuiltIn)
+                        }
+
+                        SettingsRow("Summary Style") {
+                            Picker("", selection: optionalStyleBinding(for: index)) {
+                                Text("Default").tag(String?.none)
+                                ForEach(SummaryStyle.allCases, id: \.rawValue) { style in
+                                    Text(style.rawValue.capitalized).tag(Optional(style.rawValue))
+                                }
+                            }
+                            .labelsHidden()
+                            .disabled(isBuiltIn)
+                        }
+
+                        SettingsRow("Language") {
+                            TextField("auto", text: optionalStringBinding(for: index, keyPath: \.language))
+                                .disabled(isBuiltIn)
+                        }
+
+                        SettingsRow("Suggested Duration") {
+                            OptionalIntField(
+                                value: $templates[index].suggestedDurationMinutes,
+                                placeholder: "None",
+                                suffix: "min"
+                            )
+                            .disabled(isBuiltIn)
+                        }
+                    }
+
+                    if isBuiltIn {
+                        Text("Built-in templates are read-only. Duplicate to customize.")
+                            .font(DS.Typography.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(DS.Spacing.md)
+            }
+            .onChange(of: templates) { _, _ in
+                persistTemplates()
+            }
+        } else {
+            ContentUnavailableView(
+                "No Template Selected",
+                systemImage: "doc.text",
+                description: Text("Select a template from the list to view or edit.")
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var selectedTemplate: MeetingTemplate? {
+        templates.first { $0.id == selectedTemplateID }
+    }
+
+    private var selectedIsBuiltIn: Bool {
+        selectedTemplate?.isBuiltIn ?? true
+    }
+
+    private var selectedTemplateIndex: Int? {
+        guard let id = selectedTemplateID else { return nil }
+        return templates.firstIndex { $0.id == id }
+    }
+
+    private func addTemplate() {
+        let template = MeetingTemplate(
+            name: "New Template",
+            icon: "doc.text",
+            description: ""
+        )
+        templates.append(template)
+        selectedTemplateID = template.id
+        persistTemplates()
+        Self.logger.info("Created new custom template: \(template.id)")
+    }
+
+    private func deleteSelected() {
+        guard let id = selectedTemplateID else { return }
+        MeetingTemplateStore.deleteTemplate(id: id, from: &templates)
+        selectedTemplateID = nil
+        persistTemplates()
+        Self.logger.info("Deleted template: \(id)")
+    }
+
+    private func duplicateSelected(_ template: MeetingTemplate) {
+        let copy = MeetingTemplateStore.duplicateTemplate(template)
+        templates.append(copy)
+        selectedTemplateID = copy.id
+        persistTemplates()
+        Self.logger.info("Duplicated template \(template.id) as \(copy.id)")
+    }
+
+    private func persistTemplates() {
+        MeetingTemplateStore.saveTemplates(templates)
+    }
+
+    // MARK: - Bindings
+
+    private func optionalStyleBinding(for index: Int) -> Binding<String?> {
+        Binding(
+            get: { templates[index].summaryStyle },
+            set: { templates[index].summaryStyle = $0 }
+        )
+    }
+
+    private func optionalStringBinding(for index: Int, keyPath: WritableKeyPath<MeetingTemplate, String?>) -> Binding<String> {
+        Binding(
+            get: { templates[index][keyPath: keyPath] ?? "" },
+            set: { newValue in
+                templates[index][keyPath: keyPath] = newValue.isEmpty ? nil : newValue
+            }
+        )
+    }
+}
+
+// MARK: - OptionalIntField
+
+/// A text field that binds to an optional Int, showing a placeholder when nil.
+private struct OptionalIntField: View {
+    @Binding var value: Int?
+    let placeholder: String
+    let suffix: String
+
+    var body: some View {
+        HStack(spacing: DS.Spacing.xs) {
+            TextField(placeholder, value: $value, format: .number)
+                .frame(width: 80)
+            Text(suffix)
+                .font(DS.Typography.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/notetaker/Views/TemplatePickerView.swift
+++ b/notetaker/Views/TemplatePickerView.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+/// Sheet displayed before recording starts, letting the user choose a meeting template.
+struct TemplatePickerView: View {
+    let onSelect: (MeetingTemplate?) -> Void
+    @State private var templates: [MeetingTemplate] = []
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: DS.Spacing.lg) {
+            Text("Choose a Template")
+                .font(DS.Typography.title)
+
+            Text("Select a meeting type to configure recording settings, or skip to use defaults.")
+                .font(DS.Typography.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 160), spacing: DS.Spacing.md)],
+                spacing: DS.Spacing.md
+            ) {
+                ForEach(templates) { template in
+                    TemplateCard(template: template) {
+                        onSelect(template)
+                        dismiss()
+                    }
+                }
+            }
+
+            HStack {
+                Spacer()
+                Button("Skip") {
+                    onSelect(nil)
+                    dismiss()
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+            }
+        }
+        .padding(DS.Spacing.lg)
+        .frame(minWidth: 500, minHeight: 300)
+        .onAppear {
+            templates = MeetingTemplateStore.loadTemplates()
+        }
+    }
+}
+
+// MARK: - TemplateCard
+
+private struct TemplateCard: View {
+    let template: MeetingTemplate
+    let onTap: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(spacing: DS.Spacing.sm) {
+                Image(systemName: template.icon)
+                    .font(.title)
+                    .foregroundStyle(.blue)
+
+                Text(template.name)
+                    .font(DS.Typography.body)
+                    .fontWeight(.medium)
+
+                Text(template.description)
+                    .font(DS.Typography.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+
+                if let duration = template.suggestedDurationMinutes {
+                    Text("~\(duration) min")
+                        .font(DS.Typography.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(DS.Spacing.md)
+            .background(isHovered ? Color.accentColor.opacity(0.08) : Color.clear)
+            .clipShape(RoundedRectangle(cornerRadius: DS.Radius.md))
+            .overlay(
+                RoundedRectangle(cornerRadius: DS.Radius.md)
+                    .strokeBorder(.quaternary, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+        .accessibilityLabel("Template: \(template.name)")
+    }
+}

--- a/notetakerTests/MeetingTemplateTests.swift
+++ b/notetakerTests/MeetingTemplateTests.swift
@@ -1,0 +1,180 @@
+import Testing
+import Foundation
+@testable import notetaker
+
+@Suite("MeetingTemplate Tests")
+struct MeetingTemplateTests {
+
+    @Test("Built-in templates count is 5")
+    func builtInCount() {
+        let builtIns = MeetingTemplateStore.builtInTemplates
+        #expect(builtIns.count == 5)
+    }
+
+    @Test("Built-in templates have stable UUIDs and isBuiltIn flag")
+    func builtInProperties() {
+        let builtIns = MeetingTemplateStore.builtInTemplates
+        for template in builtIns {
+            #expect(template.isBuiltIn == true)
+            #expect(!template.name.isEmpty)
+            #expect(!template.icon.isEmpty)
+            #expect(!template.description.isEmpty)
+        }
+        // Verify stable UUIDs
+        #expect(builtIns[0].id == UUID(uuidString: "A0000001-0000-0000-0000-000000000001")!)
+        #expect(builtIns[1].id == UUID(uuidString: "A0000001-0000-0000-0000-000000000002")!)
+    }
+
+    @Test("loadTemplates returns built-ins on fresh state")
+    func loadTemplatesReturnsBuiltIns() throws {
+        // Use a temp URL to avoid touching real storage
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // loadTemplates always includes built-ins even if file doesn't exist
+        let templates = MeetingTemplateStore.loadTemplates()
+        #expect(templates.count >= 5)
+        #expect(templates.filter(\.isBuiltIn).count == 5)
+    }
+
+    @Test("deleteTemplate does not delete built-in")
+    func deleteBuiltInNoop() {
+        var templates = MeetingTemplateStore.builtInTemplates
+        let countBefore = templates.count
+        MeetingTemplateStore.deleteTemplate(id: templates[0].id, from: &templates)
+        #expect(templates.count == countBefore)
+    }
+
+    @Test("deleteTemplate removes custom template")
+    func deleteCustomTemplate() {
+        var templates = MeetingTemplateStore.builtInTemplates
+        let custom = MeetingTemplate(name: "Custom", icon: "star", description: "Test")
+        templates.append(custom)
+        #expect(templates.count == 6)
+
+        MeetingTemplateStore.deleteTemplate(id: custom.id, from: &templates)
+        #expect(templates.count == 5)
+        #expect(!templates.contains(where: { $0.id == custom.id }))
+    }
+
+    @Test("duplicateTemplate creates copy with new ID and name suffix")
+    func duplicateTemplate() {
+        let original = MeetingTemplateStore.builtInTemplates[0]
+        let copy = MeetingTemplateStore.duplicateTemplate(original)
+
+        #expect(copy.id != original.id)
+        #expect(copy.name == "\(original.name) (Copy)")
+        #expect(copy.icon == original.icon)
+        #expect(copy.isBuiltIn == false)
+        #expect(copy.summaryIntervalMinutes == original.summaryIntervalMinutes)
+        #expect(copy.summaryStyle == original.summaryStyle)
+    }
+
+    @Test("JSON round-trip encoding and decoding")
+    func jsonRoundTrip() throws {
+        let template = MeetingTemplate(
+            name: "Test",
+            icon: "mic",
+            description: "A test template",
+            isBuiltIn: false,
+            summaryIntervalMinutes: 10,
+            summaryStyle: "bullets",
+            language: "en",
+            suggestedDurationMinutes: 30
+        )
+
+        let data = try JSONEncoder().encode(template)
+        let decoded = try JSONDecoder().decode(MeetingTemplate.self, from: data)
+
+        #expect(decoded.id == template.id)
+        #expect(decoded.name == template.name)
+        #expect(decoded.icon == template.icon)
+        #expect(decoded.description == template.description)
+        #expect(decoded.isBuiltIn == template.isBuiltIn)
+        #expect(decoded.summaryIntervalMinutes == template.summaryIntervalMinutes)
+        #expect(decoded.summaryStyle == template.summaryStyle)
+        #expect(decoded.language == template.language)
+        #expect(decoded.suggestedDurationMinutes == template.suggestedDurationMinutes)
+    }
+
+    @Test("Template with all optional fields nil")
+    func allOptionalFieldsNil() throws {
+        let template = MeetingTemplate(
+            name: "Minimal",
+            icon: "doc",
+            description: "No overrides"
+        )
+
+        #expect(template.summaryIntervalMinutes == nil)
+        #expect(template.summaryStyle == nil)
+        #expect(template.language == nil)
+        #expect(template.aiRecipeID == nil)
+        #expect(template.llmProfileID == nil)
+        #expect(template.suggestedDurationMinutes == nil)
+
+        // Verify nil fields survive JSON round-trip
+        let data = try JSONEncoder().encode(template)
+        let decoded = try JSONDecoder().decode(MeetingTemplate.self, from: data)
+        #expect(decoded.summaryIntervalMinutes == nil)
+        #expect(decoded.summaryStyle == nil)
+        #expect(decoded.language == nil)
+        #expect(decoded.aiRecipeID == nil)
+        #expect(decoded.llmProfileID == nil)
+        #expect(decoded.suggestedDurationMinutes == nil)
+    }
+
+    @Test("Template with all optional fields populated")
+    func allOptionalFieldsPopulated() throws {
+        let recipeID = UUID()
+        let profileID = UUID()
+        let template = MeetingTemplate(
+            name: "Full",
+            icon: "star.fill",
+            description: "All fields set",
+            isBuiltIn: false,
+            summaryIntervalMinutes: 5,
+            summaryStyle: "paragraph",
+            language: "ja",
+            aiRecipeID: recipeID,
+            llmProfileID: profileID,
+            suggestedDurationMinutes: 60
+        )
+
+        let data = try JSONEncoder().encode(template)
+        let decoded = try JSONDecoder().decode(MeetingTemplate.self, from: data)
+
+        #expect(decoded.summaryIntervalMinutes == 5)
+        #expect(decoded.summaryStyle == "paragraph")
+        #expect(decoded.language == "ja")
+        #expect(decoded.aiRecipeID == recipeID)
+        #expect(decoded.llmProfileID == profileID)
+        #expect(decoded.suggestedDurationMinutes == 60)
+    }
+
+    @Test("MeetingTemplate conforms to Hashable")
+    func hashableConformance() {
+        let t1 = MeetingTemplate(name: "A", icon: "a", description: "a")
+        let t2 = MeetingTemplate(name: "B", icon: "b", description: "b")
+        let set: Set<MeetingTemplate> = [t1, t2, t1]
+        #expect(set.count == 2)
+    }
+
+    @Test("Built-in General Meeting has expected config")
+    func generalMeetingConfig() {
+        let general = MeetingTemplateStore.builtInTemplates.first { $0.name == "General Meeting" }
+        #expect(general != nil)
+        #expect(general?.summaryIntervalMinutes == 10)
+        #expect(general?.summaryStyle == "bullets")
+        #expect(general?.suggestedDurationMinutes == nil)
+    }
+
+    @Test("Built-in Lecture template has expected config")
+    func lectureTemplateConfig() {
+        let lecture = MeetingTemplateStore.builtInTemplates.first { $0.name == "Lecture / Talk" }
+        #expect(lecture != nil)
+        #expect(lecture?.summaryIntervalMinutes == 30)
+        #expect(lecture?.summaryStyle == "paragraph")
+        #expect(lecture?.suggestedDurationMinutes == 60)
+    }
+}


### PR DESCRIPTION
## Summary
- `MeetingTemplate` model with name, icon, config overrides (summary interval/style/language), optional recipe/profile IDs
- `MeetingTemplateStore` (nonisolated enum) — JSON file storage, 5 built-in templates (General Meeting, Standup/Sync, 1-on-1, Brainstorm, Lecture/Talk) with stable UUIDs
- `TemplatePickerView` — grid sheet shown before recording, select template or skip; controlled by `@AppStorage("showTemplatePickerOnRecord")`
- `TemplateManagerView` — Settings tab for template CRUD (built-ins read-only, custom fully editable)
- ContentView integration: template picker before `startRecording()`, applies overrides to `SummarizerConfig` in UserDefaults
- 12 unit tests covering store logic, JSON round-trip, and built-in template properties

Closes #97

## Test plan
- [x] Build succeeds
- [x] 12 unit tests pass (MeetingTemplateTests)
- [ ] Manual: click Record → template picker appears → select Standup → verify 5min summary interval applied
- [ ] Manual: click Record → Skip → recording starts with default config
- [ ] Manual: Settings → Templates → create custom template → verify it appears in picker
- [ ] Manual: Settings → Templates → duplicate built-in → edit copy → verify changes saved
- [ ] Manual: Settings → Templates → toggle "Show template picker" off → Record starts immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)