### PR TITLE
feat: Spotlight indexing for system-wide session search

### DIFF
--- a/notetaker/ContentView.swift
+++ b/notetaker/ContentView.swift
@@ -3,6 +3,7 @@ import SwiftData
 
 struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @Bindable var viewModel: RecordingViewModel
     var schedulerViewModel: SchedulerViewModel
     @State private var selectedSessionID: UUID?
@@ -84,6 +85,12 @@ struct ContentView: View {
         .onChange(of: viewModel.state) { _, newState in
             if newState == .completed {
                 handleCompletionIfNeeded()
+            }
+        }
+        .onChange(of: appDelegate.spotlightSessionID) { _, newID in
+            if let newID {
+                selectedSessionID = newID
+                appDelegate.spotlightSessionID = nil
             }
         }
     }

--- a/notetaker/Services/BackgroundSummaryService.swift
+++ b/notetaker/Services/BackgroundSummaryService.swift
@@ -152,6 +152,10 @@ final class BackgroundSummaryService {
                 try context.save()
                 Self.logger.info("Background summary saved for session \(sessionID) (\(content.count) chars)")
 
+                // Update Spotlight index with new summary data
+                let spotlightData = SpotlightIndexer.sessionData(from: currentSession)
+                Task.detached { await SpotlightIndexer.shared.indexSession(spotlightData) }
+
                 // Generate title after summary
                 await Self.generateTitle(
                     sessionID: sessionID,
@@ -207,6 +211,10 @@ final class BackgroundSummaryService {
             currentSession.title = title
             try context.save()
             logger.info("Title generated for session \(sessionID) (\(title.count) chars)")
+
+            // Update Spotlight index with new title
+            let spotlightData = SpotlightIndexer.sessionData(from: currentSession)
+            Task.detached { await SpotlightIndexer.shared.indexSession(spotlightData) }
         } catch is CancellationError {
             logger.info("Title generation cancelled for \(sessionID)")
         } catch {

--- a/notetaker/Services/SpotlightIndexer.swift
+++ b/notetaker/Services/SpotlightIndexer.swift
@@ -1,0 +1,165 @@
+import CoreSpotlight
+import UniformTypeIdentifiers
+import os
+
+/// Lightweight data carrier for passing session info across isolation boundaries.
+nonisolated struct SpotlightSessionData: Sendable {
+    let id: UUID
+    let title: String
+    let transcriptExcerpt: String
+    let summaryExcerpt: String
+    let createdAt: Date
+}
+
+/// Indexes recording sessions into macOS Spotlight for system-wide search.
+nonisolated final class SpotlightIndexer: @unchecked Sendable {
+    static let shared = SpotlightIndexer()
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "notetaker",
+        category: "SpotlightIndexer"
+    )
+    static let domainIdentifier = "com.notetaker.session"
+
+    private let searchableIndex: CSSearchableIndex
+
+    init(searchableIndex: CSSearchableIndex = .default()) {
+        self.searchableIndex = searchableIndex
+    }
+
+    // MARK: - Public API
+
+    /// Index a single session into Spotlight.
+    func indexSession(_ data: SpotlightSessionData) async {
+        let item = makeSearchableItem(from: data)
+        do {
+            try await searchableIndex.indexSearchableItems([item])
+            Self.logger.info("Indexed session \(data.id) into Spotlight")
+        } catch {
+            Self.logger.error("Failed to index session \(data.id): \(error.localizedDescription)")
+        }
+    }
+
+    /// Remove a session from Spotlight by ID.
+    func deindexSession(id: UUID) async {
+        do {
+            try await searchableIndex.deleteSearchableItems(withIdentifiers: [id.uuidString])
+            Self.logger.info("Deindexed session \(id) from Spotlight")
+        } catch {
+            Self.logger.error("Failed to deindex session \(id): \(error.localizedDescription)")
+        }
+    }
+
+    /// Remove multiple sessions from Spotlight by IDs.
+    func deindexSessions(ids: Set<UUID>) async {
+        let identifiers = ids.map(\.uuidString)
+        do {
+            try await searchableIndex.deleteSearchableItems(withIdentifiers: identifiers)
+            Self.logger.info("Deindexed \(ids.count) session(s) from Spotlight")
+        } catch {
+            Self.logger.error("Failed to deindex \(ids.count) session(s): \(error.localizedDescription)")
+        }
+    }
+
+    /// Batch reindex all sessions — deletes existing indexes first.
+    func reindexAll(sessions: [SpotlightSessionData]) async {
+        Self.logger.info("Reindexing \(sessions.count) session(s) in Spotlight")
+        do {
+            try await searchableIndex.deleteSearchableItems(withDomainIdentifiers: [Self.domainIdentifier])
+        } catch {
+            Self.logger.error("Failed to clear existing Spotlight index: \(error.localizedDescription)")
+        }
+
+        guard !sessions.isEmpty else { return }
+
+        let items = sessions.map { makeSearchableItem(from: $0) }
+        do {
+            try await searchableIndex.indexSearchableItems(items)
+            Self.logger.info("Reindexed \(sessions.count) session(s) into Spotlight")
+        } catch {
+            Self.logger.error("Failed to reindex sessions: \(error.localizedDescription)")
+        }
+    }
+
+    /// Clear all Spotlight indexes for this app domain.
+    func deleteAllIndexes() async {
+        do {
+            try await searchableIndex.deleteSearchableItems(withDomainIdentifiers: [Self.domainIdentifier])
+            Self.logger.info("Cleared all Spotlight indexes")
+        } catch {
+            Self.logger.error("Failed to clear Spotlight indexes: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Static Helpers
+
+    /// Build `SpotlightSessionData` from a `RecordingSession` model object.
+    /// Must be called on the MainActor (RecordingSession is a SwiftData @Model).
+    @MainActor
+    static func sessionData(from session: RecordingSession) -> SpotlightSessionData {
+        let transcriptExcerpt = session.segments
+            .sorted { $0.startTime < $1.startTime }
+            .map(\.text)
+            .joined(separator: " ")
+            .prefix(500)
+
+        let summaryExcerpt = session.summaries
+            .filter { $0.isOverall }
+            .first
+            .map(\.displayContent)
+            .map { String($0.prefix(300)) } ?? ""
+
+        return SpotlightSessionData(
+            id: session.id,
+            title: session.title,
+            transcriptExcerpt: String(transcriptExcerpt),
+            summaryExcerpt: summaryExcerpt,
+            createdAt: session.startedAt
+        )
+    }
+
+    /// Parse a session UUID from an `NSUserActivity` triggered by Spotlight.
+    static func sessionID(from userActivity: NSUserActivity) -> UUID? {
+        guard let identifier = userActivity.userInfo?[CSSearchableItemActivityIdentifier] as? String else {
+            return nil
+        }
+        return UUID(uuidString: identifier)
+    }
+
+    // MARK: - Private
+
+    private func makeSearchableItem(from data: SpotlightSessionData) -> CSSearchableItem {
+        let attributes = CSSearchableItemAttributeSet(contentType: .text)
+        attributes.title = data.title.isEmpty ? "Recording" : data.title
+        attributes.contentDescription = buildContentDescription(
+            transcript: data.transcriptExcerpt,
+            summary: data.summaryExcerpt
+        )
+        attributes.keywords = buildKeywords(from: data.title)
+        attributes.timestamp = data.createdAt
+
+        return CSSearchableItem(
+            uniqueIdentifier: data.id.uuidString,
+            domainIdentifier: Self.domainIdentifier,
+            attributeSet: attributes
+        )
+    }
+
+    private func buildContentDescription(transcript: String, summary: String) -> String {
+        var parts: [String] = []
+        if !transcript.isEmpty {
+            parts.append(transcript)
+        }
+        if !summary.isEmpty {
+            parts.append(summary)
+        }
+        return parts.joined(separator: "\n\n")
+    }
+
+    private func buildKeywords(from title: String) -> [String] {
+        guard !title.isEmpty else { return [] }
+        return title.split(separator: " ")
+            .map(String.init)
+            .filter { $0.count > 1 }
+    }
+}

--- a/notetaker/ViewModels/RecordingViewModel.swift
+++ b/notetaker/ViewModels/RecordingViewModel.swift
@@ -579,6 +579,10 @@ final class RecordingViewModel {
         do {
             try modelContext.save()
             Self.logger.info("Session saved with \(self.segments.count) segments\(includeSummaries ? ", \(self.summaries.count) summaries" : "")")
+
+            // Index into Spotlight for system-wide search
+            let spotlightData = SpotlightIndexer.sessionData(from: session)
+            Task.detached { await SpotlightIndexer.shared.indexSession(spotlightData) }
         } catch {
             errorMessage = "Failed to save session: \(error.localizedDescription)"
         }

--- a/notetaker/Views/AboutTab.swift
+++ b/notetaker/Views/AboutTab.swift
@@ -1,6 +1,9 @@
 import SwiftUI
+import SwiftData
 
 struct AboutTab: View {
+    @Query private var sessions: [RecordingSession]
+    @State private var isRebuilding = false
     private var appVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
     }
@@ -40,6 +43,29 @@ struct AboutTab: View {
                      destination: PrivacyDisclosureView.privacyPolicyURL)
             }
             .font(DS.Typography.body)
+
+            Divider()
+                .frame(maxWidth: 300)
+
+            // Maintenance
+            Button {
+                isRebuilding = true
+                let dataList = sessions.map { SpotlightIndexer.sessionData(from: $0) }
+                Task.detached {
+                    await SpotlightIndexer.shared.reindexAll(sessions: dataList)
+                    await MainActor.run { isRebuilding = false }
+                }
+            } label: {
+                if isRebuilding {
+                    ProgressView()
+                        .controlSize(.small)
+                        .padding(.trailing, DS.Spacing.xs)
+                    Text("Rebuilding...")
+                } else {
+                    Label("Rebuild Spotlight Index", systemImage: "magnifyingglass")
+                }
+            }
+            .disabled(isRebuilding)
 
             Spacer()
 

--- a/notetaker/Views/SessionListView.swift
+++ b/notetaker/Views/SessionListView.swift
@@ -166,6 +166,9 @@ struct SessionListView: View {
         do {
             try modelContext.save()
             Self.logger.info("Deleted \(count) session(s)")
+
+            // Remove from Spotlight index
+            Task.detached { await SpotlightIndexer.shared.deindexSessions(ids: ids) }
         } catch {
             Self.logger.error("Failed to delete sessions: \(error.localizedDescription)")
         }

--- a/notetaker/notetakerApp.swift
+++ b/notetaker/notetakerApp.swift
@@ -1,14 +1,31 @@
 import SwiftUI
 import SwiftData
+import CoreSpotlight
 import os
 
 class AppDelegate: NSObject, NSApplicationDelegate {
     var viewModel: RecordingViewModel?
     var schedulerViewModel: SchedulerViewModel?
     var modelContainer: ModelContainer?
+    /// Set by Spotlight deep link; ContentView observes this to navigate.
+    var spotlightSessionID: UUID?
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         false
+    }
+
+    func application(
+        _ application: NSApplication,
+        continue userActivity: NSUserActivity,
+        restorationHandler: @escaping ([any NSUserActivityRestoring]) -> Void
+    ) -> Bool {
+        guard userActivity.activityType == CSSearchableItemActionType,
+              let sessionID = SpotlightIndexer.sessionID(from: userActivity) else {
+            return false
+        }
+        spotlightSessionID = sessionID
+        NSApp.activate()
+        return true
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {

--- a/notetakerTests/SpotlightIndexerTests.swift
+++ b/notetakerTests/SpotlightIndexerTests.swift
@@ -1,0 +1,194 @@
+import Testing
+import CoreSpotlight
+import Foundation
+@testable import notetaker
+
+@Suite("SpotlightIndexer")
+struct SpotlightIndexerTests {
+
+    // MARK: - SpotlightSessionData
+
+    @Test
+    func sessionDataInit() {
+        let id = UUID()
+        let date = Date()
+        let data = SpotlightSessionData(
+            id: id,
+            title: "Test Session",
+            transcriptExcerpt: "Hello world",
+            summaryExcerpt: "A summary",
+            createdAt: date
+        )
+        #expect(data.id == id)
+        #expect(data.title == "Test Session")
+        #expect(data.transcriptExcerpt == "Hello world")
+        #expect(data.summaryExcerpt == "A summary")
+        #expect(data.createdAt == date)
+    }
+
+    // MARK: - sessionID(from:)
+
+    @Test
+    func sessionIDFromUserActivity() {
+        let id = UUID()
+        let activity = NSUserActivity(activityType: CSSearchableItemActionType)
+        activity.userInfo = [CSSearchableItemActivityIdentifier: id.uuidString]
+
+        let parsed = SpotlightIndexer.sessionID(from: activity)
+        #expect(parsed == id)
+    }
+
+    @Test
+    func sessionIDFromUserActivityMissingIdentifier() {
+        let activity = NSUserActivity(activityType: CSSearchableItemActionType)
+        activity.userInfo = [:]
+
+        let parsed = SpotlightIndexer.sessionID(from: activity)
+        #expect(parsed == nil)
+    }
+
+    @Test
+    func sessionIDFromUserActivityNilUserInfo() {
+        let activity = NSUserActivity(activityType: CSSearchableItemActionType)
+
+        let parsed = SpotlightIndexer.sessionID(from: activity)
+        #expect(parsed == nil)
+    }
+
+    @Test
+    func sessionIDFromUserActivityInvalidUUID() {
+        let activity = NSUserActivity(activityType: CSSearchableItemActionType)
+        activity.userInfo = [CSSearchableItemActivityIdentifier: "not-a-uuid"]
+
+        let parsed = SpotlightIndexer.sessionID(from: activity)
+        #expect(parsed == nil)
+    }
+
+    // MARK: - Index / Deindex smoke tests (real CSSearchableIndex)
+
+    @Test
+    func indexSessionDoesNotThrow() async {
+        let indexer = SpotlightIndexer()
+        let data = SpotlightSessionData(
+            id: UUID(),
+            title: "Smoke Test",
+            transcriptExcerpt: "transcript text",
+            summaryExcerpt: "summary text",
+            createdAt: Date()
+        )
+        // Should complete without error
+        await indexer.indexSession(data)
+    }
+
+    @Test
+    func deindexSessionDoesNotThrow() async {
+        let indexer = SpotlightIndexer()
+        // Deindexing a nonexistent ID should not throw
+        await indexer.deindexSession(id: UUID())
+    }
+
+    @Test
+    func deindexSessionsDoesNotThrow() async {
+        let indexer = SpotlightIndexer()
+        await indexer.deindexSessions(ids: [UUID(), UUID()])
+    }
+
+    @Test
+    func reindexAllDoesNotThrow() async {
+        let indexer = SpotlightIndexer()
+        let sessions = [
+            SpotlightSessionData(id: UUID(), title: "A", transcriptExcerpt: "a", summaryExcerpt: "", createdAt: Date()),
+            SpotlightSessionData(id: UUID(), title: "B", transcriptExcerpt: "b", summaryExcerpt: "s", createdAt: Date()),
+        ]
+        await indexer.reindexAll(sessions: sessions)
+    }
+
+    @Test
+    func reindexAllEmptyDoesNotThrow() async {
+        let indexer = SpotlightIndexer()
+        await indexer.reindexAll(sessions: [])
+    }
+
+    @Test
+    func deleteAllIndexesDoesNotThrow() async {
+        let indexer = SpotlightIndexer()
+        await indexer.deleteAllIndexes()
+    }
+
+    // MARK: - sessionData(from:) with SwiftData
+
+    @MainActor @Test
+    func sessionDataFromRecordingSession() {
+        let session = RecordingSession(
+            startedAt: Date(timeIntervalSince1970: 1000),
+            title: "My Recording"
+        )
+        let seg1 = TranscriptSegment(startTime: 0, endTime: 5, text: "Hello")
+        let seg2 = TranscriptSegment(startTime: 5, endTime: 10, text: "World")
+        seg1.session = session
+        seg2.session = session
+        session.segments = [seg1, seg2]
+
+        let summary = SummaryBlock(coveringFrom: 0, coveringTo: 10, content: "Overall notes", isOverall: true)
+        summary.session = session
+        session.summaries = [summary]
+
+        let data = SpotlightIndexer.sessionData(from: session)
+        #expect(data.id == session.id)
+        #expect(data.title == "My Recording")
+        #expect(data.transcriptExcerpt == "Hello World")
+        #expect(data.summaryExcerpt == "Overall notes")
+        #expect(data.createdAt == session.startedAt)
+    }
+
+    @MainActor @Test
+    func sessionDataTruncatesTranscriptAt500Chars() {
+        let session = RecordingSession(title: "Long")
+        let longText = String(repeating: "A", count: 600)
+        let seg = TranscriptSegment(startTime: 0, endTime: 1, text: longText)
+        seg.session = session
+        session.segments = [seg]
+
+        let data = SpotlightIndexer.sessionData(from: session)
+        #expect(data.transcriptExcerpt.count == 500)
+    }
+
+    @MainActor @Test
+    func sessionDataTruncatesSummaryAt300Chars() {
+        let session = RecordingSession(title: "Long Summary")
+        let longSummary = String(repeating: "B", count: 400)
+        let summary = SummaryBlock(coveringFrom: 0, coveringTo: 1, content: longSummary, isOverall: true)
+        summary.session = session
+        session.summaries = [summary]
+
+        let data = SpotlightIndexer.sessionData(from: session)
+        #expect(data.summaryExcerpt.count == 300)
+    }
+
+    @MainActor @Test
+    func sessionDataEmptySegmentsAndSummaries() {
+        let session = RecordingSession(title: "Empty")
+
+        let data = SpotlightIndexer.sessionData(from: session)
+        #expect(data.transcriptExcerpt.isEmpty)
+        #expect(data.summaryExcerpt.isEmpty)
+    }
+
+    @MainActor @Test
+    func sessionDataIgnoresNonOverallSummaries() {
+        let session = RecordingSession(title: "Chunks Only")
+        let chunk = SummaryBlock(coveringFrom: 0, coveringTo: 5, content: "Chunk content", isOverall: false)
+        chunk.session = session
+        session.summaries = [chunk]
+
+        let data = SpotlightIndexer.sessionData(from: session)
+        #expect(data.summaryExcerpt.isEmpty)
+    }
+
+    // MARK: - Domain identifier
+
+    @Test
+    func domainIdentifierIsExpected() {
+        #expect(SpotlightIndexer.domainIdentifier == "com.notetaker.session")
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SpotlightIndexer` service for CoreSpotlight indexing of recording sessions (title, transcript excerpt, summary excerpt)
- Index sessions on persist, update index after background summary/title generation, deindex on deletion
- Deep link handling via `AppDelegate.application(_:continue:restorationHandler:)` navigates to session from Spotlight results
- "Rebuild Spotlight Index" button in Settings > About tab for manual reindexing
- 17 tests covering data extraction, UUID parsing, and index operations

## Test plan
- [x] Build succeeds with `CODE_SIGNING_ALLOWED=NO`
- [x] 17/17 SpotlightIndexer tests pass
- [ ] Manual: Record a session, verify it appears in Spotlight search
- [ ] Manual: Click Spotlight result, verify app opens to that session
- [ ] Manual: Delete a session, verify it disappears from Spotlight
- [ ] Manual: Rebuild Spotlight Index button in Settings > About works

Closes #15