### PR TITLE
feat: waveform visualization with drag-to-seek

### DIFF
--- a/notetaker/DesignSystem.swift
+++ b/notetaker/DesignSystem.swift
@@ -56,5 +56,6 @@ enum DS {
         static let summaryMaxHeight: CGFloat = 300
         static let controlBarMinHeight: CGFloat = 48
         static let timeMinWidth: CGFloat = 64
+        static let waveformHeight: CGFloat = 60
     }
 }

--- a/notetaker/Services/WaveformExtractor.swift
+++ b/notetaker/Services/WaveformExtractor.swift
@@ -1,0 +1,144 @@
+import AVFoundation
+import os
+
+/// Extracts downsampled waveform amplitude data from audio files.
+nonisolated enum WaveformExtractor {
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "notetaker", category: "WaveformExtractor")
+
+    /// Normalized waveform amplitude samples with duration info.
+    struct WaveformData: Sendable {
+        let samples: [Float]       // 0.0...1.0 normalized amplitudes
+        let duration: TimeInterval
+
+        static let empty = WaveformData(samples: [], duration: 0)
+    }
+
+    /// Extract waveform data from audio file URL, downsampled to target number of samples.
+    /// Uses RMS (root-mean-square) for each window to get smooth waveform representation.
+    static func extract(from url: URL, targetSamples: Int = 2000) async throws -> WaveformData {
+        let audioFile = try AVAudioFile(forReading: url)
+        let format = audioFile.processingFormat
+        let frameCount = AVAudioFrameCount(audioFile.length)
+        let sampleRate = format.sampleRate
+        let duration = Double(frameCount) / sampleRate
+
+        guard frameCount > 0 else { return .empty }
+
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else {
+            throw WaveformError.bufferCreationFailed
+        }
+        try audioFile.read(into: buffer)
+
+        guard let channelData = buffer.floatChannelData?[0] else {
+            throw WaveformError.noChannelData
+        }
+
+        let actualSamples = min(targetSamples, Int(frameCount))
+        let samplesPerWindow = Int(frameCount) / actualSamples
+        var rmsValues = [Float]()
+        rmsValues.reserveCapacity(actualSamples)
+        var maxRMS: Float = 0
+
+        for i in 0..<actualSamples {
+            let start = i * samplesPerWindow
+            let end = min(start + samplesPerWindow, Int(frameCount))
+            var sumSquares: Float = 0
+            for j in start..<end {
+                let sample = channelData[j]
+                sumSquares += sample * sample
+            }
+            let rms = sqrt(sumSquares / Float(end - start))
+            rmsValues.append(rms)
+            maxRMS = max(maxRMS, rms)
+        }
+
+        let result: [Float]
+        if maxRMS > 0 {
+            result = rmsValues.map { $0 / maxRMS }
+        } else {
+            result = rmsValues
+        }
+
+        logger.debug("Extracted \(result.count) waveform samples from \(duration, format: .fixed(precision: 1))s audio")
+        return WaveformData(samples: result, duration: duration)
+    }
+
+    /// Extract waveform from multiple audio clips (pause/resume creates multiple files).
+    static func extract(from urls: [URL], targetSamples: Int = 2000) async throws -> WaveformData {
+        guard !urls.isEmpty else { return .empty }
+        if urls.count == 1 { return try await extract(from: urls[0], targetSamples: targetSamples) }
+
+        var allData: [WaveformData] = []
+        var totalDuration: TimeInterval = 0
+
+        for url in urls {
+            let data = try await extract(from: url, targetSamples: targetSamples)
+            totalDuration += data.duration
+            allData.append(data)
+        }
+
+        guard totalDuration > 0 else { return .empty }
+
+        var combined = [Float]()
+        combined.reserveCapacity(targetSamples)
+        for data in allData {
+            let proportion = data.duration / totalDuration
+            let sampleCount = max(1, Int(Double(targetSamples) * proportion))
+            for i in 0..<sampleCount {
+                let sourceIdx = min(
+                    Int(Double(i) / Double(sampleCount) * Double(data.samples.count)),
+                    data.samples.count - 1
+                )
+                if sourceIdx >= 0, sourceIdx < data.samples.count {
+                    combined.append(data.samples[sourceIdx])
+                }
+            }
+        }
+
+        return WaveformData(samples: combined, duration: totalDuration)
+    }
+
+    enum WaveformError: Error, LocalizedError {
+        case bufferCreationFailed
+        case noChannelData
+
+        var errorDescription: String? {
+            switch self {
+            case .bufferCreationFailed: return "Failed to create audio buffer"
+            case .noChannelData: return "No audio channel data available"
+            }
+        }
+    }
+
+    // MARK: - Pure downsampling for testing
+
+    /// Downsample raw float samples to target count using RMS windows. Pure function for testing.
+    static func downsample(_ samples: [Float], to targetCount: Int) -> [Float] {
+        guard !samples.isEmpty, targetCount > 0 else { return [] }
+        let count = min(targetCount, samples.count)
+        let windowSize = samples.count / count
+        guard windowSize > 0 else { return Array(samples.prefix(count)) }
+
+        var rmsValues = [Float]()
+        rmsValues.reserveCapacity(count)
+        var maxRMS: Float = 0
+
+        for i in 0..<count {
+            let start = i * windowSize
+            let end = min(start + windowSize, samples.count)
+            var sumSquares: Float = 0
+            for j in start..<end {
+                sumSquares += samples[j] * samples[j]
+            }
+            let rms = sqrt(sumSquares / Float(end - start))
+            rmsValues.append(rms)
+            maxRMS = max(maxRMS, rms)
+        }
+
+        if maxRMS > 0 {
+            return rmsValues.map { $0 / maxRMS }
+        } else {
+            return rmsValues
+        }
+    }
+}

--- a/notetaker/Views/SessionDetailView.swift
+++ b/notetaker/Views/SessionDetailView.swift
@@ -25,6 +25,8 @@ struct SessionDetailView: View {
     @AppStorage("chunkSummariesHidden") private var chunkSummariesHidden = false
     @State private var showChatPanel = false
     @AppStorage("chatPanelWidth") private var chatPanelWidth: Double = 320
+    @State private var waveformData: WaveformExtractor.WaveformData?
+    @State private var waveformTask: Task<Void, Never>?
 
     var body: some View {
         if isLoading {
@@ -123,6 +125,19 @@ struct SessionDetailView: View {
                 // Playback controls
                 if !session.audioFileURLs.isEmpty {
                     Divider()
+                    if let waveformData, !waveformData.samples.isEmpty {
+                        WaveformView(
+                            waveformData: waveformData,
+                            currentTime: playbackService.currentTime,
+                            duration: playbackService.duration,
+                            isPlaying: playbackService.isPlaying,
+                            onSeek: { time in
+                                playbackService.seek(to: time)
+                            }
+                        )
+                        .padding(.horizontal)
+                        .padding(.top, DS.Spacing.sm)
+                    }
                     PlaybackControlView(service: playbackService)
                 }
 
@@ -245,11 +260,14 @@ struct SessionDetailView: View {
                 summaryProgress = nil
                 scrollToTime = nil
                 showChatPanel = false
+                waveformData = nil
+                waveformTask?.cancel()
                 fetchSession()
             }
             .onDisappear {
                 playbackService.stop()
                 summaryTask?.cancel()
+                waveformTask?.cancel()
                 refreshTimer?.invalidate()
                 refreshTimer = nil
             }
@@ -290,6 +308,21 @@ struct SessionDetailView: View {
         let urls = session.audioFileURLs.filter { FileManager.default.fileExists(atPath: $0.path) }
         guard !urls.isEmpty else { return }
         playbackService.loadMultiple(urls: urls)
+        loadWaveform(urls: urls)
+    }
+
+    private func loadWaveform(urls: [URL]) {
+        waveformTask?.cancel()
+        waveformTask = Task { @MainActor in
+            do {
+                let data = try await WaveformExtractor.extract(from: urls)
+                guard !Task.isCancelled else { return }
+                waveformData = data
+            } catch {
+                guard !Task.isCancelled else { return }
+                Self.logger.error("Waveform extraction failed: \(error.localizedDescription)")
+            }
+        }
     }
 
     /// Load overall LLM config via profile store with inheritance and legacy fallback.

--- a/notetaker/Views/WaveformView.swift
+++ b/notetaker/Views/WaveformView.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+/// Audio waveform visualization with playhead, click/drag seek support.
+struct WaveformView: View {
+    let waveformData: WaveformExtractor.WaveformData
+    let currentTime: TimeInterval
+    let duration: TimeInterval
+    let isPlaying: Bool
+    var onSeek: ((TimeInterval) -> Void)?
+
+    @State private var isDragging = false
+    @State private var dragTime: TimeInterval = 0
+
+    private var displayTime: TimeInterval {
+        isDragging ? dragTime : currentTime
+    }
+
+    private var progress: CGFloat {
+        guard duration > 0 else { return 0 }
+        return CGFloat(displayTime / duration)
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .leading) {
+                Canvas { context, size in
+                    drawWaveform(context: context, size: size)
+                }
+
+                if duration > 0 {
+                    Rectangle()
+                        .fill(Color.accentColor)
+                        .frame(width: 2)
+                        .offset(x: progress * geometry.size.width - 1)
+                }
+            }
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        isDragging = true
+                        let ratio = max(0, min(1, value.location.x / geometry.size.width))
+                        dragTime = Double(ratio) * duration
+                    }
+                    .onEnded { value in
+                        let ratio = max(0, min(1, value.location.x / geometry.size.width))
+                        let seekTime = Double(ratio) * duration
+                        onSeek?(seekTime)
+                        isDragging = false
+                    }
+            )
+        }
+        .frame(height: DS.Layout.waveformHeight)
+        .clipShape(RoundedRectangle(cornerRadius: DS.Radius.sm))
+        .accessibilityLabel("Audio waveform")
+        .accessibilityValue("\(Int(displayTime)) of \(Int(duration)) seconds")
+    }
+
+    private func drawWaveform(context: GraphicsContext, size: CGSize) {
+        let samples = waveformData.samples
+        guard !samples.isEmpty else { return }
+
+        let barWidth = max(1, size.width / CGFloat(samples.count))
+        let halfHeight = size.height / 2
+        let playedColor = Color.accentColor
+        let unplayedColor = Color.secondary.opacity(0.3)
+
+        for (index, amplitude) in samples.enumerated() {
+            let x = CGFloat(index) * barWidth
+            let barHeight = max(1, CGFloat(amplitude) * halfHeight)
+            let rect = CGRect(
+                x: x,
+                y: halfHeight - barHeight,
+                width: max(1, barWidth - 0.5),
+                height: barHeight * 2
+            )
+
+            let barProgress = CGFloat(index) / CGFloat(samples.count)
+            let color = barProgress <= progress ? playedColor : unplayedColor
+            context.fill(Path(roundedRect: rect, cornerRadius: barWidth / 2), with: .color(color))
+        }
+    }
+}

--- a/notetakerTests/WaveformExtractorTests.swift
+++ b/notetakerTests/WaveformExtractorTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Testing
+@testable import notetaker
+
+@Suite("WaveformExtractor")
+struct WaveformExtractorTests {
+    @Test func downsampleBasic() {
+        let input: [Float] = [0.5, 0.5, 1.0, 1.0, 0.0, 0.0]
+        let result = WaveformExtractor.downsample(input, to: 3)
+        #expect(result.count == 3)
+        for val in result {
+            #expect(val >= 0 && val <= 1)
+        }
+    }
+
+    @Test func downsampleEmpty() {
+        let result = WaveformExtractor.downsample([], to: 100)
+        #expect(result.isEmpty)
+    }
+
+    @Test func downsampleZeroTarget() {
+        let result = WaveformExtractor.downsample([1.0, 0.5], to: 0)
+        #expect(result.isEmpty)
+    }
+
+    @Test func downsampleSilence() {
+        let input = [Float](repeating: 0, count: 100)
+        let result = WaveformExtractor.downsample(input, to: 10)
+        #expect(result.count == 10)
+        for val in result {
+            #expect(val == 0)
+        }
+    }
+
+    @Test func downsamplePreservesRelativeAmplitudes() {
+        var input = [Float](repeating: 1.0, count: 50)
+        input += [Float](repeating: 0.1, count: 50)
+        let result = WaveformExtractor.downsample(input, to: 2)
+        #expect(result.count == 2)
+        #expect(result[0] > result[1])
+    }
+
+    @Test func downsampleTargetLargerThanInput() {
+        let input: [Float] = [0.5, 1.0]
+        let result = WaveformExtractor.downsample(input, to: 100)
+        #expect(result.count == 2)
+    }
+
+    @Test func downsampleNormalizesToOne() {
+        let input: [Float] = [0.3, 0.3, 0.3, 0.3]
+        let result = WaveformExtractor.downsample(input, to: 2)
+        let maxVal = result.max() ?? 0
+        #expect(maxVal > 0.99 && maxVal <= 1.0)
+    }
+
+    @Test func waveformDataEmptyIsValid() {
+        let empty = WaveformExtractor.WaveformData.empty
+        #expect(empty.samples.isEmpty)
+        #expect(empty.duration == 0)
+    }
+
+    @Test func downsampleSingleSample() {
+        let result = WaveformExtractor.downsample([0.7], to: 1)
+        #expect(result.count == 1)
+        #expect(result[0] > 0.99)
+    }
+
+    @Test func downsampleLargeInput() {
+        let input = (0..<10000).map { Float(sin(Double($0) * 0.01)) }
+        let result = WaveformExtractor.downsample(input, to: 100)
+        #expect(result.count == 100)
+        for val in result {
+            #expect(val >= 0 && val <= 1)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `WaveformExtractor` service that extracts downsampled RMS amplitude data from audio files (single or multi-clip)
- Add `WaveformView` SwiftUI component using `Canvas` for efficient waveform rendering with played/unplayed color, playhead line, and click/drag seek
- Integrate waveform into `SessionDetailView` above playback controls, with async loading and proper lifecycle management
- Add `DS.Layout.waveformHeight` design token (60pt)
- Add 10 unit tests for the pure `downsample()` function

## Test plan
- [x] `WaveformExtractorTests` — 10 tests pass (downsample edge cases, normalization, relative amplitudes)
- [x] Build succeeds with `CODE_SIGNING_ALLOWED=NO`
- [ ] Manual: open a session with audio, verify waveform renders
- [ ] Manual: click/drag on waveform to seek, verify playhead and audio position update
- [ ] Manual: verify waveform colors change at playhead position

Closes #13