### PR TITLE
feat: performance monitor and diagnostics panel

### DIFF
--- a/notetaker/Services/DiagnosticsCollector.swift
+++ b/notetaker/Services/DiagnosticsCollector.swift
@@ -1,0 +1,223 @@
+import Foundation
+import os
+
+/// Collects system diagnostics for troubleshooting and performance monitoring.
+nonisolated enum DiagnosticsCollector {
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "notetaker", category: "DiagnosticsCollector")
+
+    // MARK: - Data Types
+
+    struct HardwareInfo: Sendable {
+        let totalMemoryGB: Int
+        let processorName: String
+        let osVersion: String
+        let appVersion: String
+        let buildNumber: String
+    }
+
+    struct StorageInfo: Sendable {
+        let databaseSizeBytes: Int64
+        let audioFilesSizeBytes: Int64
+        let audioFileCount: Int
+        let totalSizeBytes: Int64
+
+        var databaseSizeFormatted: String { formatBytes(databaseSizeBytes) }
+        var audioFilesSizeFormatted: String { formatBytes(audioFilesSizeBytes) }
+        var totalSizeFormatted: String { formatBytes(totalSizeBytes) }
+
+        private func formatBytes(_ bytes: Int64) -> String {
+            DiagnosticsCollector.formatBytes(bytes)
+        }
+    }
+
+    struct LLMInfo: Sendable {
+        let provider: String
+        let model: String
+        let baseURL: String
+        let temperature: Double
+        let maxTokens: Int
+    }
+
+    struct AudioInfo: Sendable {
+        let sampleRate: Double
+        let channels: Int
+        let bufferDuration: Double
+    }
+
+    struct CrashInfo: Sendable {
+        let hasCrashLog: Bool
+        let crashLogContent: String?
+        let crashLogDate: Date?
+    }
+
+    // MARK: - Collection
+
+    static func collectHardware() -> HardwareInfo {
+        let totalBytes = ProcessInfo.processInfo.physicalMemory
+        let totalGB = Int(totalBytes / (1024 * 1024 * 1024))
+
+        // Get processor name via sysctl
+        var size = 0
+        sysctlbyname("machdep.cpu.brand_string", nil, &size, nil, 0)
+        var cpuName = [CChar](repeating: 0, count: size)
+        sysctlbyname("machdep.cpu.brand_string", &cpuName, &size, nil, 0)
+        let processor = String(cString: cpuName).trimmingCharacters(in: .whitespaces)
+
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersionString
+        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
+        let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "Unknown"
+
+        logger.debug("Hardware: \(totalGB)GB RAM, processor=\(processor.isEmpty ? "Unknown" : processor)")
+
+        return HardwareInfo(
+            totalMemoryGB: totalGB,
+            processorName: processor.isEmpty ? "Unknown" : processor,
+            osVersion: osVersion,
+            appVersion: appVersion,
+            buildNumber: buildNumber
+        )
+    }
+
+    static func collectStorage() -> StorageInfo {
+        let fm = FileManager.default
+        let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first?
+            .appendingPathComponent("notetaker")
+
+        var dbSize: Int64 = 0
+        var audioSize: Int64 = 0
+        var audioCount = 0
+
+        if let appDir = appSupport {
+            // Database files (.store, .store-wal, .store-shm)
+            if let contents = try? fm.contentsOfDirectory(at: appDir, includingPropertiesForKeys: [.fileSizeKey]) {
+                for url in contents {
+                    let size = (try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
+                    if url.lastPathComponent.contains(".store") {
+                        dbSize += Int64(size)
+                    }
+                }
+            }
+
+            // Audio files in Recordings subdirectory
+            let recordingsDir = appDir.appendingPathComponent("Recordings")
+            if let audioFiles = try? fm.contentsOfDirectory(at: recordingsDir, includingPropertiesForKeys: [.fileSizeKey]) {
+                for url in audioFiles {
+                    let size = (try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
+                    audioSize += Int64(size)
+                    audioCount += 1
+                }
+            }
+        }
+
+        logger.debug("Storage scan: db=\(dbSize), audio=\(audioSize) (\(audioCount) files)")
+
+        return StorageInfo(
+            databaseSizeBytes: dbSize,
+            audioFilesSizeBytes: audioSize,
+            audioFileCount: audioCount,
+            totalSizeBytes: dbSize + audioSize
+        )
+    }
+
+    static func collectLLMInfo() -> LLMInfo {
+        let config = LLMProfileStore.resolveConfig(for: .live)
+        return LLMInfo(
+            provider: config.provider.displayName,
+            model: config.model,
+            baseURL: config.baseURL,
+            temperature: config.temperature,
+            maxTokens: config.maxTokens
+        )
+    }
+
+    static func collectAudioInfo() -> AudioInfo {
+        let config = AudioConfig.default
+        return AudioInfo(
+            sampleRate: config.sampleRate,
+            channels: Int(config.channels),
+            bufferDuration: Double(config.bufferDurationSeconds)
+        )
+    }
+
+    static func collectCrashInfo() -> CrashInfo {
+        let fm = FileManager.default
+        let crashPath = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first?
+            .appendingPathComponent("notetaker/CrashLogs/last_crash.log")
+
+        guard let path = crashPath, fm.fileExists(atPath: path.path) else {
+            return CrashInfo(hasCrashLog: false, crashLogContent: nil, crashLogDate: nil)
+        }
+
+        let content = try? String(contentsOf: path, encoding: .utf8)
+        let attrs = try? fm.attributesOfItem(atPath: path.path)
+        let date = attrs?[.modificationDate] as? Date
+
+        logger.debug("Crash log found: \(content?.utf8.count ?? 0) bytes")
+
+        return CrashInfo(hasCrashLog: true, crashLogContent: content, crashLogDate: date)
+    }
+
+    // MARK: - Export
+
+    static func exportReport() -> String {
+        let hw = collectHardware()
+        let storage = collectStorage()
+        let llm = collectLLMInfo()
+        let audio = collectAudioInfo()
+        let crash = collectCrashInfo()
+
+        var lines = [String]()
+        lines.append("=== Notetaker Diagnostics Report ===")
+        lines.append("Generated: \(Date().formatted())")
+        lines.append("")
+
+        lines.append("--- Hardware ---")
+        lines.append("Memory: \(hw.totalMemoryGB) GB")
+        lines.append("Processor: \(hw.processorName)")
+        lines.append("macOS: \(hw.osVersion)")
+        lines.append("App Version: \(hw.appVersion) (\(hw.buildNumber))")
+        lines.append("")
+
+        lines.append("--- Audio Pipeline ---")
+        lines.append("Sample Rate: \(Int(audio.sampleRate)) Hz")
+        lines.append("Channels: \(audio.channels)")
+        lines.append("Buffer Duration: \(Int(audio.bufferDuration))s")
+        lines.append("")
+
+        lines.append("--- LLM Engine ---")
+        lines.append("Provider: \(llm.provider)")
+        lines.append("Model: \(llm.model)")
+        lines.append("Base URL: \(llm.baseURL)")
+        lines.append("Temperature: \(String(format: "%.1f", llm.temperature))")
+        lines.append("Max Tokens: \(llm.maxTokens)")
+        lines.append("")
+
+        lines.append("--- Storage ---")
+        lines.append("Database: \(storage.databaseSizeFormatted)")
+        lines.append("Audio Files: \(storage.audioFilesSizeFormatted) (\(storage.audioFileCount) files)")
+        lines.append("Total: \(storage.totalSizeFormatted)")
+        lines.append("")
+
+        lines.append("--- Crash Log ---")
+        lines.append("Has Crash Log: \(crash.hasCrashLog)")
+        if let date = crash.crashLogDate {
+            lines.append("Last Crash: \(date.formatted())")
+        }
+
+        logger.info("Diagnostics report generated (\(lines.count) lines)")
+
+        return lines.joined(separator: "\n")
+    }
+
+    // MARK: - Pure formatting helpers for testing
+
+    static func formatBytes(_ bytes: Int64) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        return formatter.string(fromByteCount: bytes)
+    }
+
+    static func formatSampleRate(_ rate: Double) -> String {
+        "\(Int(rate)) Hz"
+    }
+}

--- a/notetaker/Views/DiagnosticsTab.swift
+++ b/notetaker/Views/DiagnosticsTab.swift
@@ -1,0 +1,177 @@
+import SwiftUI
+import os
+
+struct DiagnosticsTab: View {
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "notetaker", category: "DiagnosticsTab")
+
+    @State private var hardware: DiagnosticsCollector.HardwareInfo?
+    @State private var storage: DiagnosticsCollector.StorageInfo?
+    @State private var llmInfo: DiagnosticsCollector.LLMInfo?
+    @State private var audioInfo: DiagnosticsCollector.AudioInfo?
+    @State private var crashInfo: DiagnosticsCollector.CrashInfo?
+    @State private var showCopiedFeedback = false
+    @State private var showCrashLog = false
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: DS.Spacing.md) {
+                // Hardware section
+                if let hw = hardware {
+                    DiagnosticSection(title: "Hardware", systemImage: "cpu") {
+                        DiagnosticRow(label: "Memory", value: "\(hw.totalMemoryGB) GB")
+                        DiagnosticRow(label: "Processor", value: hw.processorName)
+                        DiagnosticRow(label: "macOS", value: hw.osVersion)
+                        DiagnosticRow(label: "App Version", value: "\(hw.appVersion) (\(hw.buildNumber))")
+                    }
+                }
+
+                // Audio section
+                if let audio = audioInfo {
+                    DiagnosticSection(title: "Audio Pipeline", systemImage: "waveform") {
+                        DiagnosticRow(label: "Sample Rate", value: "\(Int(audio.sampleRate)) Hz")
+                        DiagnosticRow(label: "Channels", value: "\(audio.channels)")
+                        DiagnosticRow(label: "Buffer Duration", value: "\(Int(audio.bufferDuration))s")
+                    }
+                }
+
+                // LLM section
+                if let llm = llmInfo {
+                    DiagnosticSection(title: "LLM Engine", systemImage: "brain") {
+                        DiagnosticRow(label: "Provider", value: llm.provider)
+                        DiagnosticRow(label: "Model", value: llm.model)
+                        DiagnosticRow(label: "Base URL", value: llm.baseURL)
+                        DiagnosticRow(label: "Temperature", value: String(format: "%.1f", llm.temperature))
+                        DiagnosticRow(label: "Max Tokens", value: "\(llm.maxTokens)")
+                    }
+                }
+
+                // Storage section
+                if let storage = storage {
+                    DiagnosticSection(title: "Storage", systemImage: "internaldrive") {
+                        DiagnosticRow(label: "Database", value: storage.databaseSizeFormatted)
+                        DiagnosticRow(label: "Audio Files", value: "\(storage.audioFilesSizeFormatted) (\(storage.audioFileCount) files)")
+                        DiagnosticRow(label: "Total", value: storage.totalSizeFormatted)
+                    }
+                }
+
+                // Crash Log section
+                if let crash = crashInfo {
+                    DiagnosticSection(title: "Crash Log", systemImage: "exclamationmark.triangle") {
+                        DiagnosticRow(label: "Has Crash Log", value: crash.hasCrashLog ? "Yes" : "No")
+                        if let date = crash.crashLogDate {
+                            DiagnosticRow(label: "Last Crash", value: date.formatted())
+                        }
+                        if crash.hasCrashLog {
+                            Button("View Crash Log") {
+                                showCrashLog = true
+                            }
+                            .font(DS.Typography.caption)
+                        }
+                    }
+                }
+
+                // Actions
+                HStack(spacing: DS.Spacing.sm) {
+                    Button {
+                        exportDiagnostics()
+                    } label: {
+                        Label(showCopiedFeedback ? "Copied!" : "Export Diagnostics", systemImage: showCopiedFeedback ? "checkmark" : "doc.on.clipboard")
+                    }
+                    .buttonStyle(.bordered)
+
+                    Button {
+                        refreshAll()
+                    } label: {
+                        Label("Refresh", systemImage: "arrow.clockwise")
+                    }
+                    .buttonStyle(.bordered)
+                }
+                .padding(.top, DS.Spacing.sm)
+            }
+            .padding()
+        }
+        .onAppear { refreshAll() }
+        .sheet(isPresented: $showCrashLog) {
+            if let content = crashInfo?.crashLogContent {
+                NavigationStack {
+                    ScrollView {
+                        Text(content)
+                            .font(.system(.caption, design: .monospaced))
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding()
+                    }
+                    .navigationTitle("Crash Log")
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Close") { showCrashLog = false }
+                        }
+                    }
+                }
+                .frame(minWidth: 500, minHeight: 400)
+            }
+        }
+    }
+
+    private func refreshAll() {
+        hardware = DiagnosticsCollector.collectHardware()
+        storage = DiagnosticsCollector.collectStorage()
+        llmInfo = DiagnosticsCollector.collectLLMInfo()
+        audioInfo = DiagnosticsCollector.collectAudioInfo()
+        crashInfo = DiagnosticsCollector.collectCrashInfo()
+        Self.logger.info("Diagnostics refreshed")
+    }
+
+    private func exportDiagnostics() {
+        let report = DiagnosticsCollector.exportReport()
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(report, forType: .string)
+        Self.logger.info("Exported diagnostics report to clipboard")
+        withAnimation { showCopiedFeedback = true }
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(1.5))
+            withAnimation { showCopiedFeedback = false }
+        }
+    }
+}
+
+// MARK: - Helper Views
+
+private struct DiagnosticSection<Content: View>: View {
+    let title: String
+    let systemImage: String
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DS.Spacing.xs) {
+            Label(title, systemImage: systemImage)
+                .font(DS.Typography.body)
+                .fontWeight(.semibold)
+
+            VStack(alignment: .leading, spacing: DS.Spacing.xxs) {
+                content
+            }
+            .padding(DS.Spacing.sm)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.quaternary)
+            .clipShape(RoundedRectangle(cornerRadius: DS.Radius.sm))
+        }
+    }
+}
+
+private struct DiagnosticRow: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        HStack {
+            Text(label)
+                .font(DS.Typography.caption)
+                .foregroundStyle(.secondary)
+                .frame(width: 120, alignment: .leading)
+            Text(value)
+                .font(DS.Typography.caption)
+                .textSelection(.enabled)
+        }
+    }
+}

--- a/notetaker/Views/SettingsView.swift
+++ b/notetaker/Views/SettingsView.swift
@@ -18,6 +18,9 @@ struct SettingsView: View {
             RecordingSettingsTab()
                 .tabItem { Label("Recording", systemImage: "mic") }
 
+            DiagnosticsTab()
+                .tabItem { Label("Diagnostics", systemImage: "stethoscope") }
+
             AboutTab()
                 .tabItem { Label("About", systemImage: "info.circle") }
         }

--- a/notetakerTests/DiagnosticsCollectorTests.swift
+++ b/notetakerTests/DiagnosticsCollectorTests.swift
@@ -1,0 +1,98 @@
+import Testing
+@testable import notetaker
+
+@Suite("DiagnosticsCollector")
+struct DiagnosticsCollectorTests {
+    @Test func collectHardwareReturnsValidInfo() {
+        let hw = DiagnosticsCollector.collectHardware()
+        #expect(hw.totalMemoryGB > 0)
+        #expect(!hw.processorName.isEmpty)
+        #expect(!hw.osVersion.isEmpty)
+    }
+
+    @Test func collectStorageReturnsNonNegative() {
+        let storage = DiagnosticsCollector.collectStorage()
+        #expect(storage.databaseSizeBytes >= 0)
+        #expect(storage.audioFilesSizeBytes >= 0)
+        #expect(storage.audioFileCount >= 0)
+        #expect(storage.totalSizeBytes >= 0)
+    }
+
+    @Test func storageTotalIsSum() {
+        let storage = DiagnosticsCollector.collectStorage()
+        #expect(storage.totalSizeBytes == storage.databaseSizeBytes + storage.audioFilesSizeBytes)
+    }
+
+    @Test func collectLLMInfoReturnsValidInfo() {
+        let llm = DiagnosticsCollector.collectLLMInfo()
+        #expect(!llm.provider.isEmpty)
+        #expect(!llm.model.isEmpty)
+        // baseURL may be empty for on-device providers (e.g., foundationModels)
+    }
+
+    @Test func collectAudioInfoReturnsDefaults() {
+        let audio = DiagnosticsCollector.collectAudioInfo()
+        #expect(audio.sampleRate > 0)
+        #expect(audio.channels > 0)
+        #expect(audio.bufferDuration > 0)
+    }
+
+    @Test func collectCrashInfoDoesNotCrash() {
+        let crash = DiagnosticsCollector.collectCrashInfo()
+        // May or may not have a crash log — just verify it doesn't crash
+        if crash.hasCrashLog {
+            #expect(crash.crashLogContent != nil)
+        }
+    }
+
+    @Test func exportReportContainsAllSections() {
+        let report = DiagnosticsCollector.exportReport()
+        #expect(report.contains("Notetaker Diagnostics Report"))
+        #expect(report.contains("Hardware"))
+        #expect(report.contains("Audio Pipeline"))
+        #expect(report.contains("LLM Engine"))
+        #expect(report.contains("Storage"))
+        #expect(report.contains("Crash Log"))
+    }
+
+    @Test func exportReportContainsHardwareDetails() {
+        let report = DiagnosticsCollector.exportReport()
+        #expect(report.contains("Memory:"))
+        #expect(report.contains("Processor:"))
+        #expect(report.contains("macOS:"))
+        #expect(report.contains("App Version:"))
+    }
+
+    @Test func formatBytesReturnsReadableString() {
+        let result = DiagnosticsCollector.formatBytes(1024 * 1024)
+        #expect(!result.isEmpty)
+    }
+
+    @Test func formatBytesZero() {
+        let result = DiagnosticsCollector.formatBytes(0)
+        #expect(!result.isEmpty)
+    }
+
+    @Test func formatSampleRate() {
+        let result = DiagnosticsCollector.formatSampleRate(16000)
+        #expect(result == "16000 Hz")
+    }
+
+    @Test func storageSizeFormatted() {
+        let storage = DiagnosticsCollector.StorageInfo(
+            databaseSizeBytes: 1024 * 1024 * 5,
+            audioFilesSizeBytes: 1024 * 1024 * 100,
+            audioFileCount: 10,
+            totalSizeBytes: 1024 * 1024 * 105
+        )
+        #expect(!storage.databaseSizeFormatted.isEmpty)
+        #expect(!storage.audioFilesSizeFormatted.isEmpty)
+        #expect(!storage.totalSizeFormatted.isEmpty)
+    }
+
+    @Test func hardwareInfoMemoryIsReasonable() {
+        let hw = DiagnosticsCollector.collectHardware()
+        #expect(hw.totalMemoryGB >= 4)
+        #expect(hw.totalMemoryGB <= 512)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `DiagnosticsCollector` service that collects hardware info, audio pipeline config, LLM engine details, storage usage, and crash log status
- Add `DiagnosticsTab` in Settings with card-based sections, export-to-clipboard, crash log viewer, and refresh button
- 13 unit tests covering all collector methods and formatting helpers

Closes #104

## Test plan
- [x] Build succeeds (`CODE_SIGNING_ALLOWED=NO`)
- [x] All 13 `DiagnosticsCollectorTests` pass
- [ ] Open Settings > Diagnostics tab, verify all sections render
- [ ] Click "Export Diagnostics" and paste to verify clipboard content
- [ ] Click "Refresh" to reload data