### PR TITLE
feat: Focus mode reminder when recording without DND

### DIFF
--- a/notetaker/ContentView.swift
+++ b/notetaker/ContentView.swift
@@ -78,6 +78,11 @@ struct ContentView: View {
             }
         }
         .frame(minWidth: 600, minHeight: 400)
+        .overlay(alignment: .top) {
+            FocusReminderBanner(isVisible: $viewModel.showFocusReminder)
+                .padding(.horizontal, DS.Spacing.md)
+                .padding(.top, DS.Spacing.sm)
+        }
         .onAppear {
             handleCompletionIfNeeded()
         }

--- a/notetaker/Services/FocusModeService.swift
+++ b/notetaker/Services/FocusModeService.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Intents
+import os
+
+/// Checks macOS Focus / Do Not Disturb status and provides recording-time reminders.
+nonisolated enum FocusModeService {
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "notetaker", category: "FocusModeService")
+
+    enum FocusStatus: Sendable {
+        case enabled    // Focus/DND is active
+        case disabled   // No Focus active
+        case unknown    // Can't determine (authorization denied or unavailable)
+    }
+
+    /// Check if Focus / Do Not Disturb is currently enabled.
+    /// Uses INFocusStatusCenter which requires Intents framework.
+    static func currentStatus() -> FocusStatus {
+        let center = INFocusStatusCenter.default
+        let status = center.focusStatus
+
+        switch status.isFocused {
+        case .some(true):
+            logger.debug("Focus mode is enabled")
+            return .enabled
+        case .some(false):
+            logger.debug("Focus mode is disabled")
+            return .disabled
+        case .none:
+            logger.debug("Focus status unknown")
+            return .unknown
+        }
+    }
+
+    /// Request authorization to read Focus status.
+    static func requestAuthorization() async -> Bool {
+        let center = INFocusStatusCenter.default
+        let status = center.focusStatus
+        let canRead = status.isFocused != nil
+        logger.info("Focus status authorization check: canRead=\(canRead)")
+        return canRead
+    }
+
+    /// Whether the user has enabled focus reminders in settings.
+    static var isReminderEnabled: Bool {
+        UserDefaults.standard.object(forKey: "focusReminderEnabled") as? Bool ?? true
+    }
+
+    /// Check if we should show a focus reminder (Focus not active + reminders enabled).
+    static func shouldShowReminder() -> Bool {
+        guard isReminderEnabled else { return false }
+        let status = currentStatus()
+        return status == .disabled
+    }
+}

--- a/notetaker/ViewModels/RecordingViewModel.swift
+++ b/notetaker/ViewModels/RecordingViewModel.swift
@@ -52,6 +52,8 @@ final class RecordingViewModel {
 
     // Duration-end prompt (2c)
     var showDurationEndPrompt = false
+    // Focus mode reminder banner
+    var showFocusReminder = false
     private(set) var scheduledInfo: ScheduledRecordingInfo?
 
     var isRecording: Bool { state == .recording }
@@ -186,6 +188,11 @@ final class RecordingViewModel {
             if let minutes = scheduledInfo?.durationMinutes {
                 remainingDurationSeconds = TimeInterval(minutes * 60)
                 startDurationEndTimer()
+            }
+
+            // Check Focus mode and show reminder if not active
+            if FocusModeService.shouldShowReminder() {
+                showFocusReminder = true
             }
         } catch {
             errorMessage = "Failed to start recording: \(error.localizedDescription)"
@@ -480,6 +487,7 @@ final class RecordingViewModel {
 
         let wasPaused = state == .paused
 
+        showFocusReminder = false
         timer?.invalidate()
         timer = nil
         summaryTimer?.invalidate()
@@ -620,6 +628,7 @@ final class RecordingViewModel {
         latestSummary = nil
         summaryError = nil
         stoppingStatus = "Saving..."
+        showFocusReminder = false
         lastSummarizedSegmentCount = 0
         nextPeriodicCoveringFrom = 0
         periodicWindowCount = 0

--- a/notetaker/Views/FocusReminderBanner.swift
+++ b/notetaker/Views/FocusReminderBanner.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+import os
+
+/// Banner suggesting the user enable Focus/DND mode during recording.
+struct FocusReminderBanner: View {
+    @Binding var isVisible: Bool
+    @AppStorage("focusReminderEnabled") private var reminderEnabled = true
+
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "notetaker", category: "FocusReminderBanner")
+
+    var body: some View {
+        if isVisible && reminderEnabled {
+            HStack(spacing: DS.Spacing.sm) {
+                Image(systemName: "moon.fill")
+                    .foregroundStyle(.purple)
+
+                VStack(alignment: .leading, spacing: DS.Spacing.xxs) {
+                    Text("Focus Mode is off")
+                        .font(DS.Typography.callout)
+                        .fontWeight(.medium)
+                    Text("Enable Do Not Disturb to avoid notification sounds in your recording.")
+                        .font(DS.Typography.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                // Open System Settings Focus
+                Button {
+                    if let url = URL(string: "x-apple.systempreferences:com.apple.Focus") {
+                        NSWorkspace.shared.open(url)
+                    }
+                    Self.logger.info("User opened Focus settings")
+                } label: {
+                    Text("Open Settings")
+                        .font(DS.Typography.caption)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
+                // Dismiss
+                Button {
+                    withAnimation(.easeOut(duration: 0.2)) {
+                        isVisible = false
+                    }
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(DS.Typography.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .help("Dismiss")
+
+                // Don't show again
+                Button {
+                    reminderEnabled = false
+                    withAnimation(.easeOut(duration: 0.2)) {
+                        isVisible = false
+                    }
+                    Self.logger.info("User disabled focus reminders")
+                } label: {
+                    Image(systemName: "bell.slash")
+                        .font(DS.Typography.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .help("Don't remind again")
+            }
+            .padding(DS.Spacing.sm)
+            .background(.ultraThinMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: DS.Radius.md))
+            .transition(.move(edge: .top).combined(with: .opacity))
+        }
+    }
+}

--- a/notetaker/Views/SettingsTab.swift
+++ b/notetaker/Views/SettingsTab.swift
@@ -216,10 +216,17 @@ struct SummarizationSettingsTab: View {
 
 struct RecordingSettingsTab: View {
     @AppStorage("vadConfigJSON") private var vadConfigJSON: String = ""
+    @AppStorage("focusReminderEnabled") private var focusReminderEnabled = true
     @State private var config: VADConfig = .default
 
     var body: some View {
         SettingsGrid {
+            SettingsRow("Focus Reminder") {
+                Toggle("", isOn: $focusReminderEnabled)
+                    .labelsHidden()
+                    .help("Show a reminder to turn on Do Not Disturb when starting a recording")
+            }
+
             SettingsRow("Voice Activity Detection") {
                 Toggle("", isOn: $config.vadEnabled)
                     .labelsHidden()

--- a/notetakerTests/FocusModeServiceTests.swift
+++ b/notetakerTests/FocusModeServiceTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+@testable import notetaker
+
+@Suite("FocusModeService", .serialized)
+struct FocusModeServiceTests {
+    @Test func currentStatusDoesNotCrash() {
+        // Just verify the API call works without crashing
+        let status = FocusModeService.currentStatus()
+        // Status could be any value depending on system state
+        switch status {
+        case .enabled, .disabled, .unknown:
+            break // All valid
+        }
+    }
+
+    @Test func focusStatusEnumCoverage() {
+        // Verify all enum cases exist
+        let cases: [FocusModeService.FocusStatus] = [.enabled, .disabled, .unknown]
+        #expect(cases.count == 3)
+    }
+
+    @Test func reminderEnabledDefaultsToTrue() {
+        // Clean slate -- if key doesn't exist, should default to true
+        let defaults = UserDefaults.standard
+        let key = "focusReminderEnabled"
+        let original = defaults.object(forKey: key)
+        defaults.removeObject(forKey: key)
+        defaults.synchronize()
+
+        #expect(FocusModeService.isReminderEnabled == true)
+
+        // Restore
+        if let original {
+            defaults.set(original, forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
+        defaults.synchronize()
+    }
+
+    @Test func reminderDisabledWhenSettingOff() {
+        let defaults = UserDefaults.standard
+        let key = "focusReminderEnabled"
+        let original = defaults.object(forKey: key)
+
+        defaults.set(false, forKey: key)
+        #expect(FocusModeService.isReminderEnabled == false)
+        #expect(!FocusModeService.shouldShowReminder())
+
+        // Restore
+        if let original {
+            defaults.set(original, forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
+    }
+
+    @Test func shouldShowReminderRespectsDisabledSetting() {
+        let defaults = UserDefaults.standard
+        let key = "focusReminderEnabled"
+        let original = defaults.object(forKey: key)
+
+        defaults.set(false, forKey: key)
+        // When reminders are disabled, should never show
+        #expect(!FocusModeService.shouldShowReminder())
+
+        // Restore
+        if let original {
+            defaults.set(original, forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
+    }
+
+    @Test func requestAuthorizationCompletes() async {
+        // Just verify it completes without hanging
+        let result = await FocusModeService.requestAuthorization()
+        // Result depends on system state -- just verify it returns
+        _ = result
+    }
+}


### PR DESCRIPTION
## Summary
- Add `FocusModeService` (`nonisolated enum`) that checks macOS Focus/DND status via `INFocusStatusCenter`
- Add `FocusReminderBanner` overlay in `ContentView` shown when recording starts without Focus mode active — includes "Open Settings" (opens Focus system preferences), dismiss, and "don't remind again" buttons
- Add `focusReminderEnabled` toggle in Recording settings tab
- 6 tests covering status API, defaults behavior, and setting-gated logic

## Test plan
- [x] Build succeeds (`CODE_SIGNING_ALLOWED=NO`)
- [x] `FocusModeServiceTests` — 6/6 pass
- [ ] Manual: start recording with Focus off — banner appears
- [ ] Manual: dismiss banner — disappears with animation
- [ ] Manual: "Don't remind again" — persists across recordings
- [ ] Manual: toggle off in Settings > Recording — no banner on next recording
- [ ] Manual: "Open Settings" button opens System Settings Focus pane

Closes #103