### PR TITLE
feat: system audio capture via ScreenCaptureKit

### DIFF
--- a/notetaker/Services/SystemAudioCaptureService.swift
+++ b/notetaker/Services/SystemAudioCaptureService.swift
@@ -1,0 +1,246 @@
+import ScreenCaptureKit
+import AVFoundation
+import os
+
+/// Audio source selection for recording.
+enum AudioSource: String, CaseIterable, Sendable {
+    case microphone = "microphone"
+    case systemAudio = "systemAudio"
+    case both = "both"
+
+    var displayName: String {
+        switch self {
+        case .microphone: return "Microphone"
+        case .systemAudio: return "System Audio"
+        case .both: return "Both"
+        }
+    }
+}
+
+/// Captures system audio output via ScreenCaptureKit (Zoom, Meet, Teams, etc.).
+///
+/// Unlike `AudioCaptureService` (which uses `AVAudioEngine` input tap for mic),
+/// this service uses `SCStream` to capture system audio output — audio from other apps.
+/// Requires Screen Recording permission (macOS TCC).
+nonisolated final class SystemAudioCaptureService: NSObject, @unchecked Sendable {
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "notetaker",
+        category: "SystemAudioCaptureService"
+    )
+
+    // State protected by lock
+    private struct State {
+        var stream: SCStream?
+        var isCapturing = false
+        var onAudioBuffer: (@Sendable (AVAudioPCMBuffer) -> Void)?
+        var onAudioLevel: (@Sendable (Float) -> Void)?
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+    private let captureQueue = DispatchQueue(
+        label: "com.notetaker.systemAudioCapture",
+        qos: .userInteractive
+    )
+
+    /// Check if Screen Recording permission is available.
+    /// Note: There's no direct API to check — we try to enumerate content.
+    static func checkPermission() async -> Bool {
+        do {
+            _ = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+            return true
+        } catch {
+            logger.warning("Screen Recording permission not granted: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    /// Start capturing system audio.
+    func startCapture(
+        sampleRate: Double = 16000,
+        channelCount: Int = 1,
+        onAudioBuffer: @escaping @Sendable (AVAudioPCMBuffer) -> Void,
+        onAudioLevel: (@Sendable (Float) -> Void)? = nil
+    ) async throws {
+        let alreadyCapturing = state.withLock { $0.isCapturing }
+        guard !alreadyCapturing else {
+            throw SystemAudioError.captureAlreadyRunning
+        }
+
+        Self.logger.info("Starting system audio capture at \(sampleRate)Hz")
+
+        // Get shareable content to create filter
+        let content = try await SCShareableContent.excludingDesktopWindows(
+            false, onScreenWindowsOnly: false
+        )
+
+        // We need at least one display to create a content filter for audio-only capture
+        guard let display = content.displays.first else {
+            throw SystemAudioError.noDisplayAvailable
+        }
+
+        // Create filter that captures the entire display (we only want audio)
+        let filter = SCContentFilter(display: display, excludingWindows: [])
+
+        // Configure for audio-only capture
+        let config = SCStreamConfiguration()
+        config.capturesAudio = true
+        config.excludesCurrentProcessAudio = true
+        config.sampleRate = Int(sampleRate)
+        config.channelCount = channelCount
+
+        // Minimize video overhead since we only want audio
+        config.width = 2
+        config.height = 2
+        config.minimumFrameInterval = CMTime(value: 1, timescale: 1)
+        config.showsCursor = false
+
+        let stream = SCStream(filter: filter, configuration: config, delegate: self)
+
+        // Add audio output
+        try stream.addStreamOutput(self, type: .audio, sampleHandlerQueue: captureQueue)
+
+        state.withLock {
+            $0.onAudioBuffer = onAudioBuffer
+            $0.onAudioLevel = onAudioLevel
+            $0.stream = stream
+        }
+
+        try await stream.startCapture()
+
+        state.withLock { $0.isCapturing = true }
+        Self.logger.info("System audio capture started successfully")
+    }
+
+    /// Stop capturing system audio.
+    func stopCapture() async {
+        let stream = state.withLock { s -> SCStream? in
+            s.isCapturing = false
+            s.onAudioBuffer = nil
+            s.onAudioLevel = nil
+            let stream = s.stream
+            s.stream = nil
+            return stream
+        }
+
+        if let stream {
+            do {
+                try await stream.stopCapture()
+                Self.logger.info("System audio capture stopped")
+            } catch {
+                Self.logger.error("Error stopping system audio capture: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    var isCapturing: Bool {
+        state.withLock { $0.isCapturing }
+    }
+
+    // MARK: - Error Types
+
+    enum SystemAudioError: Error, LocalizedError {
+        case noDisplayAvailable
+        case permissionDenied
+        case captureAlreadyRunning
+
+        var errorDescription: String? {
+            switch self {
+            case .noDisplayAvailable:
+                return "No display available for audio capture"
+            case .permissionDenied:
+                return "Screen Recording permission is required for system audio capture"
+            case .captureAlreadyRunning:
+                return "System audio capture is already running"
+            }
+        }
+    }
+}
+
+// MARK: - SCStreamDelegate
+
+extension SystemAudioCaptureService: SCStreamDelegate {
+    nonisolated func stream(_ stream: SCStream, didStopWithError error: any Error) {
+        Self.logger.error("System audio stream stopped with error: \(error.localizedDescription)")
+        state.withLock {
+            $0.isCapturing = false
+            $0.stream = nil
+        }
+    }
+}
+
+// MARK: - SCStreamOutput
+
+extension SystemAudioCaptureService: SCStreamOutput {
+    nonisolated func stream(
+        _ stream: SCStream,
+        didOutputSampleBuffer sampleBuffer: CMSampleBuffer,
+        of type: SCStreamOutputType
+    ) {
+        guard type == .audio else { return }
+
+        // Convert CMSampleBuffer to AVAudioPCMBuffer
+        guard let formatDescription = sampleBuffer.formatDescription,
+              let asbd = CMAudioFormatDescriptionGetStreamBasicDescription(formatDescription) else {
+            return
+        }
+
+        guard let format = AVAudioFormat(streamDescription: asbd),
+              let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) else {
+            return
+        }
+
+        let frameCount = CMSampleBufferGetNumSamples(sampleBuffer)
+        guard frameCount > 0,
+              let pcmBuffer = AVAudioPCMBuffer(
+                  pcmFormat: format,
+                  frameCapacity: AVAudioFrameCount(frameCount)
+              ) else {
+            return
+        }
+        pcmBuffer.frameLength = AVAudioFrameCount(frameCount)
+
+        // Copy audio data from CMBlockBuffer to AVAudioPCMBuffer
+        var dataLength = 0
+        var dataPointer: UnsafeMutablePointer<Int8>?
+        CMBlockBufferGetDataPointer(
+            blockBuffer, atOffset: 0, lengthAtOffsetOut: nil,
+            totalLengthOut: &dataLength, dataPointerOut: &dataPointer
+        )
+
+        guard let dataPointer else { return }
+
+        if asbd.pointee.mFormatFlags & kAudioFormatFlagIsFloat != 0,
+           let destPointer = pcmBuffer.floatChannelData?[0] {
+            // Float32 format — direct copy
+            let bytesToCopy = min(dataLength, Int(frameCount) * MemoryLayout<Float>.size)
+            memcpy(destPointer, dataPointer, bytesToCopy)
+        } else if asbd.pointee.mFormatFlags & kAudioFormatFlagIsSignedInteger != 0,
+                  asbd.pointee.mBitsPerChannel == 16,
+                  let destPointer = pcmBuffer.int16ChannelData?[0] {
+            // Int16 format — direct copy
+            let bytesToCopy = min(dataLength, Int(frameCount) * MemoryLayout<Int16>.size)
+            memcpy(destPointer, dataPointer, bytesToCopy)
+        } else {
+            Self.logger.warning("Unsupported audio format flags: \(asbd.pointee.mFormatFlags)")
+            return
+        }
+
+        // Calculate audio level for metering
+        if let channelData = pcmBuffer.floatChannelData?[0] {
+            var sum: Float = 0
+            let count = Int(pcmBuffer.frameLength)
+            for i in 0..<count {
+                sum += channelData[i] * channelData[i]
+            }
+            let rms = sqrt(sum / max(1, Float(count)))
+            // Convert to 0-1 scale (log scale, -50dB to 0dB)
+            let db = 20 * log10(max(rms, 1e-7))
+            let level = max(0, min(1, (db + 50) / 50))
+
+            state.withLock { $0.onAudioLevel?(level) }
+        }
+
+        // Forward buffer to consumer (ASR engine)
+        state.withLock { $0.onAudioBuffer?(pcmBuffer) }
+    }
+}

--- a/notetaker/ViewModels/RecordingViewModel.swift
+++ b/notetaker/ViewModels/RecordingViewModel.swift
@@ -57,6 +57,11 @@ final class RecordingViewModel {
     var isRecording: Bool { state == .recording }
     var isActive: Bool { state == .recording || state == .paused }
 
+    /// Current audio source read from UserDefaults.
+    var audioSource: AudioSource {
+        AudioSource(rawValue: UserDefaults.standard.string(forKey: "audioSource") ?? "") ?? .microphone
+    }
+
     private let audioCaptureService: AudioCaptureService
     private let asrEngine: any ASREngine
     private var timer: Timer?
@@ -73,6 +78,7 @@ final class RecordingViewModel {
     private var periodicWindowCount: Int = 0
     private var llmConfigObserver: NSObjectProtocol?
     private let vadConfig: VADConfig
+    private var systemAudioService: SystemAudioCaptureService?
 
     // Duration-end timer state (2c)
     private var durationEndTimer: Timer?
@@ -193,10 +199,24 @@ final class RecordingViewModel {
     }
 
     private func checkPermissions() async -> Bool {
-        let micGranted = await audioCaptureService.requestPermission()
-        guard micGranted else {
-            errorMessage = "Microphone permission denied"
-            return false
+        let source = audioSource
+
+        // Mic permission needed for .microphone and .both
+        if source == .microphone || source == .both {
+            let micGranted = await audioCaptureService.requestPermission()
+            guard micGranted else {
+                errorMessage = "Microphone permission denied"
+                return false
+            }
+        }
+
+        // Screen Recording permission needed for .systemAudio and .both
+        if source == .systemAudio || source == .both {
+            let screenGranted = await SystemAudioCaptureService.checkPermission()
+            guard screenGranted else {
+                errorMessage = "Screen Recording permission is required for system audio capture. Please enable it in System Settings > Privacy & Security > Screen Recording."
+                return false
+            }
         }
 
         if SFSpeechRecognizer.authorizationStatus() != .authorized {
@@ -215,8 +235,10 @@ final class RecordingViewModel {
     }
 
     private func startAudioPipeline() throws -> URL {
-        // 0. Configure VAD before audio starts
-        if vadConfig.vadEnabled {
+        let source = audioSource
+
+        // 0. Configure VAD before audio starts (mic-based only)
+        if (source == .microphone || source == .both) && vadConfig.vadEnabled {
             let inputFormat = audioCaptureService.audioEngine.inputNode.outputFormat(forBus: 0)
             // Buffer size matches the tap's hardcoded 1024 in AudioCaptureService.startCapture()
             let bufferDuration = 1024.0 / inputFormat.sampleRate
@@ -241,22 +263,26 @@ final class RecordingViewModel {
 
         // 1. Wire up buffer forwarding BEFORE audio starts
         let engine = asrEngine
-        audioCaptureService.onAudioBuffer = { buffer in
-            engine.appendAudioBuffer(buffer)
+        if source == .microphone || source == .both {
+            audioCaptureService.onAudioBuffer = { buffer in
+                engine.appendAudioBuffer(buffer)
+            }
         }
 
         // 2. Wire audio level metering (throttle on audio thread to avoid Task spam)
         let meter = audioMeter
         let lastLevel = OSAllocatedUnfairLock(initialState: Float(0))
-        audioCaptureService.onAudioLevel = { level in
-            let shouldUpdate = lastLevel.withLock { last -> Bool in
-                guard abs(last - level) > 0.02 else { return false }
-                last = level
-                return true
-            }
-            if shouldUpdate {
-                Task { @MainActor in
-                    meter.update(level)
+        if source == .microphone || source == .both {
+            audioCaptureService.onAudioLevel = { level in
+                let shouldUpdate = lastLevel.withLock { last -> Bool in
+                    guard abs(last - level) > 0.02 else { return false }
+                    last = level
+                    return true
+                }
+                if shouldUpdate {
+                    Task { @MainActor in
+                        meter.update(level)
+                    }
                 }
             }
         }
@@ -264,8 +290,60 @@ final class RecordingViewModel {
         // 3. Start ASR (creates recognition request ready to receive buffers)
         try asrEngine.startRecognition(audioEngine: audioCaptureService.audioEngine)
 
-        // 4. Start audio capture LAST (tap installed, engine starts, audio flows to ASR)
-        return try audioCaptureService.startCapture()
+        // 4. Start mic audio capture (tap installed, engine starts, audio flows to ASR)
+        let fileURL: URL
+        if source == .microphone || source == .both {
+            fileURL = try audioCaptureService.startCapture()
+        } else {
+            // System-audio-only: still need a file URL for the session, but no mic capture
+            let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+            let filename = "system_audio_\(UUID().uuidString).m4a"
+            fileURL = documentsURL.appendingPathComponent(filename)
+        }
+
+        // 5. Start system audio capture if needed
+        if source == .systemAudio || source == .both {
+            let sysService = SystemAudioCaptureService()
+            systemAudioService = sysService
+
+            // Wire system audio buffers to ASR engine
+            let sysOnBuffer: @Sendable (AVAudioPCMBuffer) -> Void = { buffer in
+                engine.appendAudioBuffer(buffer)
+            }
+
+            // Wire system audio level metering (used when system-audio-only)
+            var sysOnLevel: (@Sendable (Float) -> Void)?
+            if source == .systemAudio {
+                sysOnLevel = { level in
+                    let shouldUpdate = lastLevel.withLock { last -> Bool in
+                        guard abs(last - level) > 0.02 else { return false }
+                        last = level
+                        return true
+                    }
+                    if shouldUpdate {
+                        Task { @MainActor in
+                            meter.update(level)
+                        }
+                    }
+                }
+            }
+
+            let capturedOnLevel = sysOnLevel
+            Task { @MainActor [weak self] in
+                do {
+                    try await sysService.startCapture(
+                        onAudioBuffer: sysOnBuffer,
+                        onAudioLevel: capturedOnLevel
+                    )
+                    Self.logger.info("System audio capture started alongside recording")
+                } catch {
+                    Self.logger.error("Failed to start system audio capture: \(error.localizedDescription)")
+                    self?.errorMessage = "System audio capture failed: \(error.localizedDescription)"
+                }
+            }
+        }
+
+        return fileURL
     }
 
     private func createSession(fileURL: URL, scheduledInfo: ScheduledRecordingInfo? = nil) {
@@ -308,6 +386,13 @@ final class RecordingViewModel {
         // 3. Stop audio capture (saves current clip file, clears VAD)
         if let savedURL = audioCaptureService.stopCapture() {
             Self.logger.info("Clip saved to \(savedURL.path)")
+        }
+
+        // 3b. Stop system audio capture if running
+        if let sysService = systemAudioService {
+            let service = sysService
+            systemAudioService = nil
+            await service.stopCapture()
         }
 
         // 4. Drain ASR results for current clip
@@ -498,6 +583,15 @@ final class RecordingViewModel {
             } else {
                 Self.logger.warning("stopCapture returned nil — no audio file was saved")
             }
+
+            // Stop system audio capture if running
+            if let sysService = systemAudioService {
+                let service = sysService
+                systemAudioService = nil
+                Task {
+                    await service.stopCapture()
+                }
+            }
         }
 
         if let session = currentSession {
@@ -658,6 +752,8 @@ final class RecordingViewModel {
             audioCaptureService.onAudioLevel = nil
             audioCaptureService.onSilenceTimeout = nil
             _ = audioCaptureService.stopCapture()
+            // System audio service cleanup (fire-and-forget on force quit)
+            systemAudioService = nil
         }
 
         if let session = currentSession {

--- a/notetaker/Views/SettingsTab.swift
+++ b/notetaker/Views/SettingsTab.swift
@@ -216,10 +216,21 @@ struct SummarizationSettingsTab: View {
 
 struct RecordingSettingsTab: View {
     @AppStorage("vadConfigJSON") private var vadConfigJSON: String = ""
+    @AppStorage("audioSource") private var audioSource: String = AudioSource.microphone.rawValue
     @State private var config: VADConfig = .default
 
     var body: some View {
         SettingsGrid {
+            SettingsRow("Audio Source") {
+                Picker("", selection: $audioSource) {
+                    ForEach(AudioSource.allCases, id: \.rawValue) { source in
+                        Text(source.displayName).tag(source.rawValue)
+                    }
+                }
+                .labelsHidden()
+                .help("Choose audio input: microphone only, system audio (Zoom/Meet/Teams), or both")
+            }
+
             SettingsRow("Voice Activity Detection") {
                 Toggle("", isOn: $config.vadEnabled)
                     .labelsHidden()

--- a/notetakerTests/SystemAudioCaptureServiceTests.swift
+++ b/notetakerTests/SystemAudioCaptureServiceTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+@testable import notetaker
+
+@Suite("SystemAudioCaptureService")
+struct SystemAudioCaptureServiceTests {
+    @Test func audioSourceEnumCases() {
+        #expect(AudioSource.allCases.count == 3)
+        #expect(AudioSource.microphone.rawValue == "microphone")
+        #expect(AudioSource.systemAudio.rawValue == "systemAudio")
+        #expect(AudioSource.both.rawValue == "both")
+    }
+
+    @Test func audioSourceDisplayNames() {
+        #expect(AudioSource.microphone.displayName == "Microphone")
+        #expect(AudioSource.systemAudio.displayName == "System Audio")
+        #expect(AudioSource.both.displayName == "Both")
+    }
+
+    @Test func audioSourceFromRawValue() {
+        #expect(AudioSource(rawValue: "microphone") == .microphone)
+        #expect(AudioSource(rawValue: "systemAudio") == .systemAudio)
+        #expect(AudioSource(rawValue: "both") == .both)
+        #expect(AudioSource(rawValue: "invalid") == nil)
+    }
+
+    @Test func serviceInitialState() {
+        let service = SystemAudioCaptureService()
+        #expect(!service.isCapturing)
+    }
+
+    @Test func errorDescriptions() {
+        let errors: [SystemAudioCaptureService.SystemAudioError] = [
+            .noDisplayAvailable, .permissionDenied, .captureAlreadyRunning,
+        ]
+        for error in errors {
+            #expect(error.errorDescription != nil)
+            #expect(!error.errorDescription!.isEmpty)
+        }
+    }
+
+    @Test func permissionCheckCompletes() async {
+        // Just verify it doesn't hang — result depends on system state
+        let result = await SystemAudioCaptureService.checkPermission()
+        _ = result
+    }
+
+    @Test func stopCaptureWhenNotRunning() async {
+        let service = SystemAudioCaptureService()
+        // Should not crash when stopping without starting
+        await service.stopCapture()
+        #expect(!service.isCapturing)
+    }
+
+    @Test func audioSourceDefaultIsMicrophone() {
+        let defaults = UserDefaults.standard
+        let key = "audioSource"
+        let original = defaults.string(forKey: key)
+        defaults.removeObject(forKey: key)
+
+        let source = AudioSource(rawValue: defaults.string(forKey: key) ?? AudioSource.microphone.rawValue)
+        #expect(source == .microphone)
+
+        // Restore
+        if let original {
+            defaults.set(original, forKey: key)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SystemAudioCaptureService` using `SCStream` to capture system-wide audio output (Zoom, Meet, Teams, etc.) via ScreenCaptureKit
- Add `AudioSource` enum with three modes: `.microphone`, `.systemAudio`, `.both` — configurable in Settings > Recording
- Integrate system audio into `RecordingViewModel`: permission checks, start/stop/pause lifecycle, buffer forwarding to ASR engine
- Add 8 unit tests covering enum cases, error descriptions, service state, and permission check

## Implementation Details
- `SystemAudioCaptureService` follows the same `nonisolated final class: @unchecked Sendable` + `OSAllocatedUnfairLock<State>` pattern as `AudioCaptureService`
- Captures audio-only via `SCStream` with minimal video overhead (2x2px, 1fps)
- `excludesCurrentProcessAudio = true` prevents feedback loops
- CMSampleBuffer → AVAudioPCMBuffer conversion handles both Float32 and Int16 formats
- Audio level metering uses same -50dB to 0dB log scale as mic capture
- Screen Recording permission checked via `SCShareableContent` enumeration

## Test plan
- [x] `AudioSource` enum raw values and display names
- [x] Service initial state (not capturing)
- [x] Error descriptions non-empty
- [x] Permission check completes without hanging
- [x] Stop capture when not running (no crash)
- [x] Default audio source is microphone
- [ ] Manual: verify system audio capture with a Zoom/Meet call
- [ ] Manual: verify "Both" mode captures mic + system audio simultaneously

Closes #114